### PR TITLE
Fixing hero link colour contrast per WCAG 2.1 AA

### DIFF
--- a/assets/sass/content.sass
+++ b/assets/sass/content.sass
@@ -19,6 +19,10 @@ $content-table-head-cell-color: $text-strong !default
 $content-table-foot-cell-border-width: 2px 0 0 !default
 $content-table-foot-cell-color: $text-strong !default
 
+.hero.is-primary a
+  color: #173d4f
+  &:hover
+    color: #000
 .content
   @extend %block
   // Inline


### PR DESCRIPTION
Addresses #20 by changing link colours in the hero to #173d4f to meet W3C WCAG 2.1 AA colour contrast. 

![Screenshot from 2020-11-19 22-14-04](https://user-images.githubusercontent.com/620580/99647581-de7bc580-2ab6-11eb-8d25-8173e43e0558.png)

This PR doesn't address the non-linked text colour of white (from Bulma) which fails this colour contrast test.

![Screenshot from 2020-11-19 22-07-27](https://user-images.githubusercontent.com/620580/99647759-1551db80-2ab7-11eb-964b-80d96435daad.png)

![Screenshot from 2020-11-19 22-34-19](https://user-images.githubusercontent.com/620580/99648101-885b5200-2ab7-11eb-83ff-970d3e622b43.png)

Bulma's primary background is a gradient so the exact colour behind any text changes, but these two sample values are indicative of the gradient colour.
