### PR TITLE
Update TSC page (fix ##39)

### DIFF
--- a/content/governance/tsc/README.md
+++ b/content/governance/tsc/README.md
@@ -6,66 +6,39 @@ The TSC is responsible for technical oversight of the Servo Project, as laid out
 
 Current members:
 
-- [Alan Jeffrey](https://github.com/asajeffrey) (chair)
+- [Alan Jeffrey](https://github.com/asajeffrey)
 - [Anthony Ramine](https://github.com/nox)
 - [Connor Brewster](https://github.com/cbrewster)
 - [Cheng-You Bai](https://github.com/cybai)
+- [Delan Azabani](https://github.com/delan)
 - [Diane Hosfelt](https://github.com/avadacatavra)
 - [Emilio Cobos Álvarez](https://github.com/emilio)
 - [Fernando Jiménez Moreno](https://github.com/ferjm)
 - [Gregory Terzian](https://github.com/gterzian)
 - [Jack Moffitt](https://github.com/metajack)
 - [James Graham](https://github.com/jgraham)
+- [Josh Aas](https://github.com/bdaehlie)
 - [Josh Matthews](https://github.com/jdm) (secretary)
 - [Keith Yeung](https://github.com/KiChjang)
+- [Manuel Rego](https://github.com/mrego) (chair)
 - [Manish Goregaokar](https://github.com/Manishearth)
 - [Martin Robinson](https://github.com/mrobinson)
+- [Oriol Brufau](https://github.com/Loirooriol)
 - [Patrick Walton](https://github.com/pcwalton)
+- [Philip Lamb](https://github.com/philip-lamb)
 - [Paul Rouget](https://github.com/paulrouget)
 - [Simon Sapin](https://github.com/SimonSapin)
-
-Past members:
-
-- [Lars Bergstrom](https://github.com/larsbergstrom)
 
 ## Meetings
 
 The TSC meets in public, and all minutes are published.
 
-* [12 Feb 2020](tsc-2021-02-12.md)
-* [11 Dec 2020](tsc-2020-12-11.md)
-* [9 Oct 2020](tsc-2020-10-09.md)
-
-Launch subcommittee meetings:
-* [20 Nov 2020](launch-2020-11-20.md)
-* [13 Nov 2020](launch-2020-11-13.md)
-* [06 Nov 2020](launch-2020-11-06.md)
-* [30 Oct 2020](launch-2020-10-30.md)
-* [23 Oct 2020](launch-2020-10-23.md)
-* [16 Oct 2020](launch-2020-10-16.md)
-
-Infrastructure subcommittee meetings:
-* [4 Dec 2020](infra-2020-12-04.md)
-* [27 Nov 2020](infra-2020-11-27.md)
+Meeting minutes can be found at [GitHub Servo Project repository](https://github.com/servo/project/blob/master/governance/tsc/README.md).
 
 ## Subcommittees
 
 The TSC can form subcommittees for detailed discussion of issues.
 Contact the TSC secretary to join a subcommittee.
 
-- infrastructure
-  - [Josh Matthews](https://github.com/jdm)
-  - [Alan Jeffrey](https://github.com/asajeffrey)
-- technical direction
-  - [Josh Matthews](https://github.com/jdm)
-  - [Cheng-You Bai](https://github.com/cybai)
-  - [Alan Jeffrey](https://github.com/asajeffrey)
-  - [Martin Robinson](https://github.com/mrobinson)
-  - [Manish Goregaokar](https://github.com/Manishearth)
+Currently there are no active subcommittees.
 
-Past subcommittees:
-
-- launch
-  - [Alan Jeffrey](https://github.com/asajeffrey)
-  - [Lars Bergstrom](https://github.com/larsbergstrom)
-  - [Simon Sapin](https://github.com/SimonSapin)


### PR DESCRIPTION
This updates the list of members.
And also links to Servo Project on GitHub for the meeting minutes.