### PR TITLE
fix heading syntax for new markdown renderer

### DIFF
--- a/_posts/2014-09-01-twis-1.md
+++ b/_posts/2014-09-01-twis-1.md
@@ -9,7 +9,7 @@ categories:
 
 In the last week, we landed 38 PRs.
 
-###Notable aditions
+### Notable aditions
 
  - Simon Sapin implemented [sideways text](https://github.com/servo/servo/pull/3181)
  - Ms2ger [turned on a portion of the HTML web platform tests](https://github.com/servo/servo/pull/3100)
@@ -18,12 +18,12 @@ In the last week, we landed 38 PRs.
  - Simon Sapin [gave canvas its own crate](https://github.com/servo/servo/pull/3178)
  - Manish Goregaokar [added CORS Cache support to the Fetch module](https://github.com/servo/servo/pull/3141)
 
-###New contributors
+### New contributors
 
  - [Gilles Leblanc](https://github.com/gilles-leblanc)
  - [Rohan Prinja](https://github.com/wenderen)
 
-###Meeting
+### Meeting
 
 Stuff discussed in [the meeting](https://github.com/servo/servo/wiki/Meeting-2014-08-25):
 

--- a/_posts/2014-09-08-twis-2.md
+++ b/_posts/2014-09-08-twis-2.md
@@ -11,18 +11,18 @@ In the last week, we landed 17 PRs. Next week should have more, as some of the w
 
 There was no meeting on September 1, as that was the US Labor Day holiday.
 
-###Notable additions
+### Notable additions
 
  - Glenn added [initial layout debugging support](https://github.com/servo/servo/pull/3206)
  - Martin added [typed units support](https://github.com/servo/servo/pull/3173) to the compositor
  - Laleh added the [power usage measurement scripts](https://github.com/servo/servo/pull/3167) she has been using to generate the graphs that appear in our LinuxCon, etc. presentations
 
-###New contributors
+### New contributors
 
  - [Sean McArthur](https://github.com/seanmonstar)
  - [Duncan Keall](https://github.com/duncankl)
 
-###Meeting
+### Meeting
 
 Stuff discussed in [the meeting](https://github.com/servo/servo/wiki/Meeting-2014-09-08):
 

--- a/_posts/2014-09-17-twis-3.md
+++ b/_posts/2014-09-17-twis-3.md
@@ -12,7 +12,7 @@ In the last week, we landed 63 PRs. Servo now uses [Cargo](http://crates.io) and
 Cargo unshackles us from makefiles and submodules (mostly), and keeps us running alongside the rest of the Rust community. Additionally, mach makes the build system easy to extend.
 
 
-###Notable additions
+### Notable additions
  - Jack [Cargoified servo](https://github.com/servo/servo/pull/3230)
  - Clark [added bloom filters for CSS selector matching](https://github.com/servo/servo/pull/3212). This resulted in a speed improvement of 3.7x for http://cnn.com
  - Patrick added [premultiplying of PNG alphas](https://github.com/servo/servo/pull/3281)
@@ -21,12 +21,12 @@ Cargo unshackles us from makefiles and submodules (mostly), and keeps us running
  - Manish [added a lint to help type-check transmutes](https://github.com/servo/servo/pull/3258)
  - Jack [fixed loading of file URLs with spaces](https://github.com/servo/servo/pull/3280)
  
-###New contributors
+### New contributors
 
  - [ProgramFOX](https://github.com/ProgramFOX)
  - [Dirk Leifeld](https://github.com/EdorianDark)
 
-###Meeting
+### Meeting
 
 Stuff discussed in [the meeting](https://github.com/servo/servo/wiki/Meeting-2014-09-15):
  

--- a/_posts/2014-09-25-twis-4.md
+++ b/_posts/2014-09-25-twis-4.md
@@ -10,7 +10,7 @@ categories:
 In the last week, we landed 54 PRs. 
 
 
-###Notable additions
+### Notable additions
  - Keegan [updated the version of Rust we use](https://github.com/servo/servo/pull/3438), bringing us to `4d2af38611cdeeb804659b5e0695ad2c251db51a`
  - Chris [implemented TreeWalker](https://github.com/servo/servo/pull/3253), finishing up [the Traversal parts of the DOM spec](https://dom.spec.whatwg.org/#traversal)
  - Cameron [partially](https://github.com/servo/servo/pull/3433) [removed](https://github.com/servo/servo/pull/3422) instances of the redundant `&JSRef` (`JSRef` itself is a smart pointer)
@@ -20,13 +20,13 @@ In the last week, we landed 54 PRs.
  - Patrick [fixed](https://github.com/servo/servo/pull/3399) handling of generated `display:block` content
  - Josh [integrated](https://github.com/servo/servo/pull/3172) remote Firefox developer tool support.
  
-###New contributors
+### New contributors
 
  - [Andreas Tolfsen](https://github.com/andreastt)
  - [Prasoon Shukla](https://github.com/prasoon2211)
  - [Jeongeun Kim](https://github.com/jejuliekim)
 
-###Meeting
+### Meeting
 
 Stuff discussed in [the meeting](https://github.com/servo/servo/wiki/Meeting-2014-09-22):
  

--- a/_posts/2014-10-01-twis-5.md
+++ b/_posts/2014-10-01-twis-5.md
@@ -9,7 +9,7 @@ categories:
 
 In the last week, we landed 47 PRs.
 
-###Notable additions
+### Notable additions
  - Glenn [improved](https://github.com/servo/servo/pull/3535) our rendering of acid2
  - Simon landed another [Rust upgrade](https://github.com/servo/servo/pull/3487)
  - Keegan [removed `servo_util::atom` and switched to string-cache's `Namespace`](https://github.com/servo/servo/pull/3530)
@@ -20,7 +20,7 @@ In the last week, we landed 47 PRs.
  - Josh and Ms2ger [created a separate smart pointer for nullable JS member pointers](https://github.com/servo/servo/pull/3531)
  - Lars [disabled Travis](https://github.com/servo/servo/pull/3473), since we now use bors
 
-###Meeting
+### Meeting
 
 Stuff discussed in [the meeting](https://github.com/servo/servo/wiki/Meeting-2014-09-29):
  

--- a/_posts/2014-10-09-twis-6.md
+++ b/_posts/2014-10-09-twis-6.md
@@ -9,7 +9,7 @@ categories:
 
 In the last week, we landed 26 PRs.
 
-###Notable additions
+### Notable additions
 
  - Josh [implemented basic support for form controls](https://github.com/servo/servo/pull/3520). We have working checkboxes and radio buttons now, with [text input](https://github.com/servo/servo/pull/3585) and form submission coming soon.
  - Patrick [fixed the hypothetical box behavior for `position:absolute` elements with `display:inline`](https://github.com/servo/servo/pull/3546)
@@ -19,12 +19,12 @@ In the last week, we landed 26 PRs.
  - Ms2ger [replaced `page.fragment_node` with `page.fragment_name`](https://github.com/servo/servo/pull/3558)
  - Simon [added better handling of runtime-loaded files and used it to load the user agent CSS at runtime](https://github.com/servo/servo/pull/3601). Cargo can create binaries in different locations depending on the type of build, this lets us load resources at runtime without needing to repeatedly deal with this.
 
-###New contributors
+### New contributors
 
  - [Andrew Guertin](https://github.com/andrewguertin)
  - [James Berlage](https://github.com/jamesberlage)
 
-###Meeting
+### Meeting
 
  - Spidermonkey/html5ever review: Going on, both should merge soon
  - Cargo/build stuff: Cargo is broken (fixed at the time of writing), and the

--- a/_posts/2014-10-14-twis-7.md
+++ b/_posts/2014-10-14-twis-7.md
@@ -11,7 +11,7 @@ categories:
 
 Since the last post, we landed 16 PRs.
 
-###Notable additions
+### Notable additions
 
  - Glenn [exposed the command-line supplied user agent through `navigator.userAgent`](https://github.com/servo/servo/pull/3608). Many sites break when they look for this property, not anymore.
  - Patrick [tweaked `box-sizing` to not affect automatically computed sizes](https://github.com/servo/servo/pull/3615)
@@ -19,7 +19,7 @@ Since the last post, we landed 16 PRs.
  - Manish [implemented basic form submission](https://github.com/servo/servo/pull/3642) via `<form>.submit()`
  - Matt [moved more windowing code out of the compositor](https://github.com/servo/servo/pull/3563)
 
-###Screenshots
+### Screenshots
 
 ![twitter](http://i.imgur.com/OrKcy0k.jpg) 
 
@@ -36,12 +36,12 @@ You can find these changes applied in order [here](https://github.com/Manisheart
 
 
 
-###New contributors
+### New contributors
 
  - [Steve Klabnik](https://github.com/steveklabnik)
  - [Robin Stocker](https://github.com/robinst)
 
-###Meeting
+### Meeting
 
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2014-10-13)
 

--- a/_posts/2014-10-20-twis-8.md
+++ b/_posts/2014-10-20-twis-8.md
@@ -8,7 +8,7 @@ categories:
 ---
 In the last week, we merged 39 pull requests.
 
-###Notable additions
+### Notable additions
  - Keegan [integrated html5ever into Servo](https://github.com/servo/servo/pull/3702)! Yay! This moves us from using bindings to libhubbub to our own HTML parser written in Rust. See [here](http://www.reddit.com/r/rust/comments/2jgdua/servo_is_now_using_html5ever_for_parsing/) for more details and discussion.
  - Glenn [added `@media` query support](https://github.com/servo/servo/pull/3610). 
  - Patrick rewrote [some of the code for intrinsic widths and table layout](https://github.com/servo/servo/pull/3609) to match the [in-progress spec](http://dbaron.org/css/intrinsic/)
@@ -16,17 +16,17 @@ In the last week, we merged 39 pull requests.
  - Martin [gave individual layers the ability to render their own background](https://github.com/servo/servo/pull/3672)
  - Patrick [optimized our handling of `font-style`](https://github.com/servo/servo/pull/3697)
 
-###Screenshots
+### Screenshots
 [![](http://i.imgur.com/PkW7x78.png)](http://i.imgur.com/PkW7x78.png)
 This is with Patrick's [work on `linear-gradient`]. Most of the buttons on GitHub now have the correct linear gradient.
 
-###New contributors
+### New contributors
  - [Ehsan Akhgari](https://github.com/ehsan)
  - [Emanuel Rylke](https://github.com/ema-fox)
  - [Kasey Carrothers](https://github.com/kaseyc)
  - [Mukilan Thiagarajan](https://github.com/mukilan)
 
-###Meeting
+### Meeting
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2014-10-20)
 
  - The November workweek was discussed. The team is probably going to plan out the work for 2015.

--- a/_posts/2014-10-28-twis-9.md
+++ b/_posts/2014-10-28-twis-9.md
@@ -9,7 +9,7 @@ categories:
 
 In the last week, we merged 38 pull requests.
 
-###Notable additions
+### Notable additions
  - Glenn [introduced a task pool for image decoding](https://github.com/servo/servo/pull/3730)
  - Patrick made a [bunch of performance changes](https://github.com/servo/servo/pull/3722)
  - Clark [improved the performance of DOM traversal](https://github.com/servo/servo/pull/3744)
@@ -24,7 +24,7 @@ In the last week, we merged 38 pull requests.
  - Bruno [improved `before_remove_attr`/`after_set_attr` to take `JSRef<Attr>`s directly and reduce allocations]
  -
 
-###Screenshots
+### Screenshots
 
 These show off [our support for CSS `@media` queries](https://github.com/servo/servo/pull/3610)
 
@@ -41,13 +41,13 @@ The [Bootstrap grid examples](http://getbootstrap.com/examples/grid/) at differe
 ![](https://i.imgur.com/EM6LZzu.png)
 
 
-###New contributors
+### New contributors
 
  - [Ray Clanan](https://github.com/rclanan)
  - [Samuel Harrington](https://github.com/samlh)
  - [Fabrice Desré](https://github.com/fabricedesre)
 
-###Meeting
+### Meeting
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2014-10-27)
 
  - Acid2: We're almost there! There's a small issue with the nose, any other issues are probably graphics driver problems. If it doesn't work for you, please consider filing an issue.

--- a/_posts/2014-11-04-twis-10.md
+++ b/_posts/2014-11-04-twis-10.md
@@ -11,7 +11,7 @@ This week, we landed 31 pull requests.
 
 Patrick got our [7000th commit](https://github.com/servo/servo/commit/a208463b62bd880f87d1650b8f8fc0866a56f609)!
 
-###Notable additions
+### Notable additions
  - Clark [fixed resize](https://github.com/servo/servo/pull/3826)
  - Clark and Patrick made [a](https://github.com/servo/servo/pull/3833) [bunch](https://github.com/servo/servo/pull/3827) [of](https://github.com/servo/servo/pull/3828) debugging changes
  - Nchinth [started work on an XML parser](https://github.com/servo/servo/pull/3718) (part of an NCSU student project)
@@ -29,7 +29,7 @@ Patrick used a profiler to make a bunch of performance improvements:
  - [Stop adding damage when removing whitespace to avoid full reflows](https://github.com/servo/servo/pull/3841)
  - [...and some microoptimizations in script](https://github.com/servo/servo/pull/3835)
 
-###Screenshots
+### Screenshots
 
 [Sliderust](https://github.com/kmcallister/sliderust) running in Servo:
 
@@ -39,12 +39,12 @@ Sliderust is a library that lets you create HTML slides using markdown and rustd
 
 The above screenshot is a sneak peek into Keegan's talk which will happen on Thursday at the SF Rust meetup
 
-###New contributors
+### New contributors
 
  - [Mitchell van der Hoeff](https://github.com/mvanderh)
  - [Nchinth](https://github.com/nchinth)
 
 
-###Meeting
+### Meeting
 
 The Servo team is currently having a work week (so no regular meeting). Yesterday, the graphics toolkit and rasterization were extensively discussed among other things.

--- a/_posts/2014-11-11-twis-11.md
+++ b/_posts/2014-11-11-twis-11.md
@@ -16,7 +16,7 @@ Last week there were many talks on Servo. Lars gave [a general intro to Servo](h
 
 
 
-###Notable additions
+### Notable additions
  - Patrick [micro-optimized `DList` and `StackingContext`](https://github.com/servo/servo/pull/3890)
  - Ms2ger implemented [`HTMLElement.title`](https://github.com/servo/servo/pull/3901/) and [`HTMLElement.lang`](https://github.com/servo/servo/pull/3914/), and made [another prefix fix](https://github.com/servo/servo/pull/3905)
  - Patrick [implemented a subset of CSS linear gradients](https://github.com/servo/servo/pull/3696)
@@ -27,20 +27,20 @@ Last week there were many talks on Servo. Lars gave [a general intro to Servo](h
  - Orvar [improved handling of snapshot download failures](https://github.com/servo/servo/pull/3894), making the newbie experience less confusing
 
 
-###New contributors
+### New contributors
 
  - [Orvar Segerström](https://github.com/awestroke)
  - [Philip Munksgaard](https://github.com/Munksgaard)
  - [Shing Lyu](https://github.com/shinglyu)
 
-###Statistics
+### Statistics
 
 You can find some cool commit stats [here](http://www.joshmatthews.net/servo-stats.html).
 
 We also have some stats on CSS property usage [here](https://docs.google.com/spreadsheets/d/1CxLS8w8GwK-2euVErrqpUUb76PiZa6w5h5EnGsL9KFs/edit?usp=sharing). More details and caveats on the same can be found [on the mailing list](https://groups.google.com/forum/#!topic/mozilla.dev.servo/iB8fZ7SUS0Q)
 
 
-###Work week
+### Work week
 
 Stuff discussed in the work week:
 
@@ -57,7 +57,7 @@ Stuff discussed in the work week:
  - [Alternate JS engine](https://github.com/servo/servo/wiki/Workweek-alt-js): Motivations for creating a new JS engine in Rust; alternatives to rewrite-the-world; further discussion tabled until mid 2015. 
  - [Script crate](https://github.com/servo/servo/wiki/Workweek-script-crate): Splitting up script/DOM-related code to reduce compile times. 
 
-###Meeting
+### Meeting
 
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2014-11-10)
 

--- a/_posts/2014-11-18-twis-12.md
+++ b/_posts/2014-11-18-twis-12.md
@@ -10,7 +10,7 @@ categories:
 This week, we merged 23 pull requests
 
 
-###Notable additions
+### Notable additions
 
  - Clark, Glenn, and Jack landed [a rust upgrade](https://github.com/servo/servo/pull/3948)
  - Josh's [single-line text input pull request](https://github.com/servo/servo/pull/3585) finally merged! Google search works in Servo now!
@@ -21,14 +21,14 @@ This week, we merged 23 pull requests
  - Mukilan [added the ability to pass  arguments to callbacks in `setTimeout()` and `setInterval()`](https://github.com/servo/servo/pull/3941)
  - Ms2ger did [some cleanups of the constellation code](https://github.com/servo/servo/pull/4019)
 
-###New contributors
+### New contributors
 
  - [Thiago Pontes](https://github.com/thiagopnts)
  - [Andrew Hobden](https://github.com/Hoverbear)
  - [Davidjz](https://github.com/davidjz)
  - [Kshitij Parajuli](https://github.com/kparaju)
 
-###Meeting
+### Meeting
 
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2014-11-17)
 

--- a/_posts/2014-11-25-twis-13.md
+++ b/_posts/2014-11-25-twis-13.md
@@ -12,7 +12,7 @@ This week, we merged 26 pull requests
 Next week we'll be in [Portland](https://wiki.mozilla.org/Portland_coincidental_work_week), and holding "getting started" sessions after hours for interested people. More information [here](https://etherpad.mozilla.org/servo-mozlandia-2014). Do come; there are [stickers](http://imgur.com/CLnfQnO) to be had!
 
 
-###Notable additions
+### Notable additions
 
  - Glennw [integrated glutin for linux](https://github.com/servo/servo/pull/4028). [Glutin is a pure rust alternative to GLFW](https://github.com/tomaka/glutin), you should check it out!
  - Patrick made some [more incremental reflow improvements](https://github.com/servo/servo/pull/3904)
@@ -23,7 +23,7 @@ Next week we'll be in [Portland](https://wiki.mozilla.org/Portland_coincidental_
  - Rohan [implemented `document.createAttribute()`](https://github.com/servo/servo/pull/4067)
  - Matt Rasmus made a [bunch](https://github.com/servo/servo/pull/4063) [of](https://github.com/servo/servo/pull/4077) [mach](https://github.com/servo/servo/pull/4090) [improvements](https://github.com/servo/servo/pull/4045), including a [mach update](https://github.com/servo/servo/pull/4080) and [the ability to run with a debugger](https://github.com/servo/servo/pull/4083)
 
-###New contributors
+### New contributors
 
 8 new contributors this week, hooray!
 
@@ -36,7 +36,7 @@ Next week we'll be in [Portland](https://wiki.mozilla.org/Portland_coincidental_
  - [Trevor Riles](https://github.com/trevorriles)
  - [Corey Farwell](https://github.com/frewsxcv)
 
-###Meeting
+### Meeting
 
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2014-11-24)
 

--- a/_posts/2014-12-09-twis-14.md
+++ b/_posts/2014-12-09-twis-14.md
@@ -17,7 +17,7 @@ We now have switched over from the deprecated [rust-http](https://github.com/chr
 
 The amazing Michael Wu has gotten Servo running on a Flame! You can try it out [here](https://github.com/servo/servo/pull/4294)
 
-###Notable additions
+### Notable additions
 
  - [This is not the `Cargo.toml` you are looking for](https://github.com/servo/servo/pull/4140)
  - Sean and Manish [integrated Hyper with Servo and added openssl to the Android build](https://github.com/servo/servo/pull/4198) respectively
@@ -32,7 +32,7 @@ The amazing Michael Wu has gotten Servo running on a Flame! You can try it out [
  - Glenn improved layout of [Google Search](https://github.com/servo/servo/pull/4114)
  - Matt Rasmus [updated mach](https://github.com/servo/servo/pull/4080) and added a [debugger flag](https://github.com/servo/servo/pull/4083)
 
-###New contributors
+### New contributors
 
 There were some after hours sessions at Mozlandia for getting people involved in Servo, which went rather well!
 
@@ -52,7 +52,7 @@ There were some after hours sessions at Mozlandia for getting people involved in
  - [Timothy Terriberry](https://github.com/tterribe)
  - [Zirak](https://github.com/Zirak)
 
-###Meeting(s)
+### Meeting(s)
 
 We had a rather productive work week, with many interesting discussions being held. A couple of topics that were discussed with other teams:
 

--- a/_posts/2014-12-16-twis-15.md
+++ b/_posts/2014-12-16-twis-15.md
@@ -9,7 +9,7 @@ categories:
 
 This week, we merged 41 pull requests
 
-###Notable additions
+### Notable additions
 
  - Patrick implemented [`word-spacing`](https://github.com/servo/servo/pull/4360), [`overflow-wrap`/`word-wrap`](https://github.com/servo/servo/pull/4361), [`outline`](https://github.com/servo/servo/pull/4299), [`letter-spacing`](https://github.com/servo/servo/pull/4325), [`box-shadow`](https://github.com/servo/servo/pull/4318), [`text-indent`](https://github.com/servo/servo/pull/4328), and [legacy `bgcolor`/`border`](https://github.com/servo/servo/pull/4289).
  - Michael landed a [gonk port](https://github.com/servo/servo/pull/4306)
@@ -19,12 +19,12 @@ This week, we merged 41 pull requests
  - Michael [added support for `rem`](https://github.com/servo/servo/pull/4340)
  - Patrick [fixed a double borrow](https://github.com/servo/servo/pull/4385/files) and [some race conditions](https://github.com/servo/servo/pull/3844)
 
-###New contributors
+### New contributors
 
  - [Chris Manchester](https://github.com/chmanchester)
  - [Michael Wu](https://github.com/michaelwu)
 
-###Meeting
+### Meeting
 
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2014-12-15)
 

--- a/_posts/2014-12-23-twis-16.md
+++ b/_posts/2014-12-23-twis-16.md
@@ -9,7 +9,7 @@ categories:
 
 This week, we merged 30 pull requests
 
-###Notable additions
+### Notable additions
 
  - Ms2ger landed [a rust upgrade](https://github.com/servo/servo/pull/4405)
  - Eddy fixed [`onload` for `<script>`](https://github.com/servo/servo/pull/4326)
@@ -18,14 +18,14 @@ This week, we merged 30 pull requests
  - James Moughan [added support for `Ctrl-A` in text inputs](https://github.com/servo/servo/pull/4457)
  - Josh [implemented `HTMLElement.style`](https://github.com/servo/servo/pull/4342)
 
-###New contributors
+### New contributors
 
  - [Adam Sunderland](https://github.com/iterion)
  - [Amanda Watson](https://github.com/amwatson)
  - [James Moughan](https://github.com/jamougha)
  - [Matt McCoy](https://github.com/mattnenterprise)
 
-###Screenshots
+### Screenshots
 
 ![](http://i.imgur.com/aB3sp9F.jpg)
 

--- a/_posts/2014-12-31-twis-17.md
+++ b/_posts/2014-12-31-twis-17.md
@@ -12,7 +12,7 @@ This week, we merged 20 pull requests
 [Glenn](https://github.com/servo/servo/commit/f579be2307185441d869834cbb5d40abe24baee7) and 
 [Manish](https://github.com/servo/servo/commit/93c350e6e38f76587966f77b436d73fdec68e00b) reached their 200th commits! Congratulations!
 
-###Notable additions
+### Notable additions
 
  - Josh added support for [thread-safe refcounting of arbitrary DOM types](https://github.com/servo/servo/pull/4057)
  - Ms2ger audited our transmutes [and removed some](https://github.com/servo/servo/pull/4490)
@@ -21,12 +21,12 @@ This week, we merged 20 pull requests
  - Manish [replaced `to_string()` calls with the faster `into_string()`](https://github.com/servo/servo/pull/4485), taking a cue from 
 [hyper](https://github.com/hyperium/hyper/pull/190)
 
-###New contributors
+### New contributors
 
  - [Benjamin Peterson](https://github.com/gutworth)
  - [Yodalee](https://github.com/yodalee)
 
-###Screenshots
+### Screenshots
 
 ![](http://i.imgur.com/UI8vcXm.png)
 

--- a/_posts/2015-01-06-twis-18.md
+++ b/_posts/2015-01-06-twis-18.md
@@ -11,7 +11,7 @@ This week, we merged 17 pull requests
 
 Vacations are over, things should pick up now!
 
-###Notable additions
+### Notable additions
 
  - Martin [fixed a rather annoying `PaintTask` leak](https://github.com/servo/servo/pull/4536) that was making it hard to use Servo's navigation
  - Ms2ger [did](https://github.com/servo/servo/pull/4542) [some](https://github.com/servo/servo/pull/4535) [pre-rustup](https://github.com/servo/servo/pull/4538) [cleanup](https://github.com/servo/servo/pull/4548)
@@ -19,7 +19,7 @@ Vacations are over, things should pick up now!
  - Shing [added support for `Blob.type`](https://github.com/servo/servo/pull/4470)
  - Megha [fixed our inheritance enums to properly reflect the structure of the inheritance](https://github.com/servo/servo/pull/4495)
 
-###New contributors
+### New contributors
 
  - [Bharath M R](https://github.com/catchmrbharath)
  - [Jim Hoskins](https://github.com/jimrhoskins)
@@ -27,7 +27,7 @@ Vacations are over, things should pick up now!
  - [Thomas Jespersen](https://github.com/laumann)
 
 
-###Meeting
+### Meeting
 
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2015-01-05)
 

--- a/_posts/2015-01-13-twis-19.md
+++ b/_posts/2015-01-13-twis-19.md
@@ -11,7 +11,7 @@ This week, we merged 41 pull requests
 
 We now support [100 CSS properties!](https://docs.google.com/spreadsheets/d/1CxLS8w8GwK-2euVErrqpUUb76PiZa6w5h5EnGsL9KFs/edit#gid=555855884)
 
-###Notable additions
+### Notable additions
 
 We landed [another Rust upgrade](https://github.com/servo/servo/pull/4554).  Next up: Rust 1.0 Alpha!
 
@@ -20,13 +20,13 @@ We landed [another Rust upgrade](https://github.com/servo/servo/pull/4554).  Nex
  - Ms2ger [turned off the usage of `unsafe` in script aside from a couple of allowed areas](https://github.com/servo/servo/pull/4584)
  - Edit [connected the Canvas render task to layout](https://github.com/servo/servo/pull/4137). Simple canvases now work.
 
-###New contributors
+### New contributors
 
  - [Arpad Borsos](https://github.com/Swatinem)
  - [Ashish Sharma](https://github.com/kartaa)
  - [Guillaume Bort](https://github.com/guillaumebort)
 
-###Screenshots
+### Screenshots
 
 Servo's first SVG! ([pull request](https://github.com/servo/servo/pull/4623))
 
@@ -36,7 +36,7 @@ We also have working certificate checking in Servo, you can try it on [this bran
 
 ![](https://pbs.twimg.com/media/B66rwGfCcAEe9Ki.png:large)
 
-###Meeting
+### Meeting
 
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2015-01-12)
 

--- a/_posts/2015-01-20-twis-20.md
+++ b/_posts/2015-01-20-twis-20.md
@@ -9,7 +9,7 @@ categories:
 
 This week, we merged 34 pull requests
 
-###Notable additions
+### Notable additions
 
  - Everyone is pitching in to the [Rust upgrade to alpha](https://github.com/servo/servo/compare/rustup_20150109)
  - Glenn added support for [multiple tabs in CEF](https://github.com/servo/servo/pull/4583)
@@ -17,7 +17,7 @@ This week, we merged 34 pull requests
  - Bruno [reduced some duplication  by sharing the CSS properties between style and script](https://github.com/servo/servo/pull/4667)
 
 
-###New contributors
+### New contributors
 
  - [Akos Kiss](https://github.com/akiss77)
  - [Christopher Hotchkiss](https://github.com/chotchki)

--- a/_posts/2015-01-27-twis-21.md
+++ b/_posts/2015-01-27-twis-21.md
@@ -12,12 +12,12 @@ This week, we merged 8 pull requests. Not many significant changes this week sin
 
 Ms2ger reached [his 1000th commit](https://github.com/servo/servo/commit/13c7cf928a5817de315a58a4fa15dc9b7fdc3d7f), and is the first on the project to do so!
 
-###Notable additions
+### Notable additions
 
  - The [rust upgrade](https://github.com/servo/servo/pull/4719) is still going on; it has now reached review.
  - Simon [landed the new CSS parser](https://github.com/servo/servo/pull/4689)
 
-##Meeting
+## Meeting
 
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2015-01-26)
 

--- a/_posts/2015-02-04-twis-22.md
+++ b/_posts/2015-02-04-twis-22.md
@@ -15,7 +15,7 @@ No birthday is complete without food. Servo got [cookie support](https://github.
 
 Josh also gave a talk on contributing to Servo at [FOSDEM](https://fosdem.org/2015/schedule/speaker/josh_matthews/). The video isn't up yet, but you can find the slides [here](http://www.joshmatthews.net/fosdem2015/).
 
-###Notable additions
+### Notable additions
 
  - Josh and Shamir added [cookie support](https://github.com/servo/servo/pull/4519) to Servo. Now you can log in to Github and some other sites. Reddit doesn't work yet, however.
  - Manish added support for [SSL certificate validation](https://github.com/servo/servo/pull/4741) via OpenSSL. [Your certificate is bad, and you should feel bad](https://pbs.twimg.com/media/B66rwGfCcAEe9Ki.png:large)
@@ -27,7 +27,7 @@ Josh also gave a talk on contributing to Servo at [FOSDEM](https://fosdem.org/20
  - Glenn removed our [GLFW version](https://github.com/servo/servo/pull/4798). We now use [glutin](https://github.com/tomaka/glutin) on both Linux and OS X.
 
 
-###New contributors
+### New contributors
 
  - [Damien Lespiau](https://github.com/dlespiau)
  - [Diego Marcos](https://github.com/dmarcos)
@@ -37,7 +37,7 @@ Josh also gave a talk on contributing to Servo at [FOSDEM](https://fosdem.org/20
  - [Wojciech Wiśniewski](https://github.com/zarazek)
 
 
-###Screenshots
+### Screenshots
 
 With cookie support, we can finally see what websites look whilst logged in!
 

--- a/_posts/2015-02-18-twis-24.md
+++ b/_posts/2015-02-18-twis-24.md
@@ -13,7 +13,7 @@ This week, we merged 37 pull requests.
 
 Servo, Rust, HTML5ever, and Hyper are participating in this year's Google Summer of Code! You can find the project ideas [here](https://wiki.mozilla.org/Community:SummerOfCode15#Rust).
 
-###Notable additions
+### Notable additions
 
  - Servo landed another [Rust upgrade](https://github.com/servo/servo/pull/4893), bringing us to the Rust version from February 2. We went through around 7 snapshots before reaching this one due to various ICEs and fixes.
  - Nick Nethercote [removed an unnecessary clone of our bloom filter](https://github.com/servo/servo/pull/4938), reducing the number of clones on a Wikipedia page by 1.2 million. With a five line patch!
@@ -23,7 +23,7 @@ Servo, Rust, HTML5ever, and Hyper are participating in this year's Google Summer
  - Glenn fixed [background-color calculations for iframes](https://github.com/servo/servo/pull/4934)
  - Nick Nethercote [fixed memory measurements for jemalloc](https://github.com/servo/servo/pull/4917)
 
-###New contributors
+### New contributors
 
  - [Alec Weber](https://github.com/awlnx)
  - [David Huffman](https://github.com/storedbox)

--- a/_posts/2015-02-24-twis-25.md
+++ b/_posts/2015-02-24-twis-25.md
@@ -15,7 +15,7 @@ Selector matching has been extracted into an independent library! You can see it
 We now have automation set up for our Gonk (Firefox OS) port, and gate on it.
 
 
-###Notable additions
+### Notable additions
 
  - Chris Paris landed [fragment parsing in html5ever](https://github.com/servo/html5ever/pull/91)
    and implemented the [innerHTML setter in Servo](https://github.com/servo/servo/pull/4888).
@@ -30,18 +30,18 @@ We now have automation set up for our Gonk (Firefox OS) port, and gate on it.
  - Nathan Froyd [added support for invoking `rr` from mach](https://github.com/servo/servo/pull/5047)
  - Shing Lyu [added activation behavior to anchors, fixing a papercut](https://github.com/servo/servo/pull/4870)
 
-###Screenshots
+### Screenshots
 
 [Parallel painting, visualized](https://github.com/servo/servo/pull/4969):
 
 ![](https://cloud.githubusercontent.com/assets/28357/6275199/7bd6e788-b83a-11e4-89cb-a74f360272f2.png)
 
-###New contributors
+### New contributors
 
  - [Andreas Gal](https://github.com/andreasgal)
  - [Paweł Kondzior](https://github.com/pkondzior)
 
-###Meeting
+### Meeting
 
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2015-02-23)
 

--- a/_posts/2015-03-03-twis-26.md
+++ b/_posts/2015-03-03-twis-26.md
@@ -10,7 +10,7 @@ categories:
 This week, we merged 50 pull requests
 
 
-###Notable additions
+### Notable additions
 
  - Josh added support for [async document loading](https://github.com/servo/servo/pull/5118)
  - Patrick [implemented `overflow-x`/`overflow-y`](https://github.com/servo/servo/pull/5132)
@@ -20,7 +20,7 @@ This week, we merged 50 pull requests
  - Ms2ger [added profiling to image decoding](https://github.com/servo/servo/pull/5102)
  - Glenn added [the ability to reap layout data when a node is removed](https://github.com/servo/servo/pull/5086)
 
-###New contributors
+### New contributors
 
  - [Arbitrary Cat](https://github.com/arbitrary-cat)
  - [Avi Weinstock](https://github.com/aweinstock314)
@@ -29,7 +29,7 @@ This week, we merged 50 pull requests
  - [Isaac Ge](https://github.com/acgtyrant)
  - [James Gilbertson](https://github.com/luniv)
 
-###Meeting
+### Meeting
 
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2015-03-02)
 

--- a/_posts/2015-03-11-twis-27.md
+++ b/_posts/2015-03-11-twis-27.md
@@ -12,14 +12,14 @@ This week, we merged 35 pull requests
 
 Want to work on the Servo team? We're hiring a [Staff Research Engineer](https://careers.mozilla.org/en-US/position/ollA0fw0) and an [Operations engineer](https://careers.mozilla.org/en-US/position/oymA0fwe)!
 
-###Notable additions
+### Notable additions
  - Patrick [implemented ordered lists, CSS counters, and `quotes`](https://github.com/servo/servo/pull/5160)
  - Matt [fixed RTL/LTR layout](https://github.com/servo/servo/pull/5143)
  - Mátyás Mustoha [added support for `arc()` in canvas](https://github.com/servo/servo/pull/5185)
  - James Gilbertson [implemented the `vw`, `vh`, `vmin`, and `vmax` CSS units](https://github.com/servo/servo/pull/5154)
  - Manish [added servobuild support for `$CARGO_HOME` and moved the default cargo cache inside the Servo root](https://github.com/servo/servo/pull/5168). We now do not create any build artefacts outside of the repo clone.
 
-###New contributors
+### New contributors
 
  - [Dan Fox](https://github.com/iamdanfox)
  - [Mátyás Mustoha](https://github.com/mmatyas)

--- a/_posts/2015-04-02-twis-29.md
+++ b/_posts/2015-04-02-twis-29.md
@@ -22,7 +22,7 @@ h5e's newest sibling is [tendril](https://github.com/kmcallister/tendril#readme)
 
 If your favorite website looks wrong in Servo, you can help us figure out why! Glenn wrote up a detailed guide on [getting started working on Servo's layout code](https://github.com/servo/servo/wiki/Getting-started-with-layout), with some useful tips for minimizing test cases. We are also working on automatic minimization via "[abstract reftests](https://github.com/servo/servo/issues/5260)".
 
-###Notable additions
+### Notable additions
 
 - We landed a [Rust upgrade](https://github.com/servo/servo/pull/5256)
 - Glenn [implemented a subset of the mozbrowser APIs](https://github.com/servo/servo/pull/5281) 
@@ -56,7 +56,7 @@ If your favorite website looks wrong in Servo, you can help us figure out why! G
  
 
 
-###New contributors
+### New contributors
 
 
  - [Brandon DeRosier](https://github.com/bdero)
@@ -75,7 +75,7 @@ If your favorite website looks wrong in Servo, you can help us figure out why! G
  - [Sebastian N. Fernandez](https://github.com/snf)
  - [Tim Cuthbertson](https://github.com/gfxmonk)
 
-###Screenshots
+### Screenshots
 
 A visualization of parallel layout on servo-shell + [/r/rust](http://www.reddit.com/r/rust):
 
@@ -85,7 +85,7 @@ The colored boxes indicate which CPU core performed layout for each document nod
 around the active tab spinner is askew, because the spinner is a still image styled with
 [`transform: rotate(...)`](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Using_CSS_transforms).
 
-###Meetings
+### Meetings
 
 We had meetings on [March
 16th](https://github.com/servo/servo/wiki/Meeting-2015-03-16) and [March

--- a/_posts/2015-04-09-twis-30.md
+++ b/_posts/2015-04-09-twis-30.md
@@ -14,7 +14,7 @@ We now use [homu](http://github.com/barosl/homu) to queue pull requests and coor
 
 Last week's post [was discussed on Hacker News](https://news.ycombinator.com/item?id=9313182).
 
-###Notable additions
+### Notable additions
 
  - James [added support](https://github.com/servo/servo/pull/5421) for running the [W3C CSS tests](https://github.com/w3c/csswg-test). This PR had commits so large that it broke GitHub and consequently our CI.
  - Lars and Manish switched the infrastructure to use homu instead of bors, with much help from Barosl.
@@ -27,7 +27,7 @@ Last week's post [was discussed on Hacker News](https://news.ycombinator.com/ite
  - Patrick [improved positioning of list images](https://github.com/servo/servo/pull/5587)
  - Matt [implemented the `:focus` selector and `element.focus()` method](https://github.com/servo/servo/pull/5461)
 
-###New contributors
+### New contributors
 
  - [Aditya Mukerjee](https://github.com/chimeracoder)
  - [Aneesh Agrawal](https://github.com/aneeshusa)
@@ -37,7 +37,7 @@ Last week's post [was discussed on Hacker News](https://news.ycombinator.com/ite
  - [Xue Fuqiao](https://github.com/xfq)
  - [Muhammad Zaheer](https://github.com/nmzaheer)
 
-###Meeting
+### Meeting
 
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2015-04-06)
 

--- a/_posts/2015-04-16-twis-31.md
+++ b/_posts/2015-04-16-twis-31.md
@@ -12,7 +12,7 @@ In the past two weeks, we merged 100 pull requests
 Lars and Mike wrote [a blog post](http://blogs.s-osg.org/servo-adapting-c-to-work-on-the-web/) on Servo on the Samsung OSG blog
 
 
-###Notable additions
+### Notable additions
 
 - Diego started off [our WebGL implementation](https://github.com/servo/servo/pull/5652)
 - Patrick [improved scrolling performance](https://github.com/servo/servo/pull/5634)
@@ -27,7 +27,7 @@ Lars and Mike wrote [a blog post](http://blogs.s-osg.org/servo-adapting-c-to-wor
 - Adenilson implemented [CSS blur filter](https://github.com/servo/servo/pull/5546). Also implemented support for displaying the Firefox [icon for broken image links](https://github.com/servo/servo/pull/5783) as a follow up to [loading a placeholder](https://github.com/servo/servo/pull/5366).
 - Adenilson implemented [dump of optimized display lists](https://github.com/servo/servo/pull/5728). Together with dumping of [regular display lists](https://github.com/servo/servo/pull/5062), dumping of [flowtree](https://github.com/servo/servo/pull/4995) and [reflow events](https://github.com/servo/servo/commit/618f56410db1f18ce05744e45e8f9651152d9ae2), debugging layout bugs in servo became easier.
 
-###New contributors
+### New contributors
 
  - [Bogdan Cuza](https://github.com/boghison)
  - [Dhananjay Nakrani](https://github.com/dhananjay92)
@@ -36,14 +36,14 @@ Lars and Mike wrote [a blog post](http://blogs.s-osg.org/servo-adapting-c-to-wor
  - [Marcus Klaas](https://github.com/marcusklaas)
  - [Peter Gonda](https://github.com/pgonda)
 
-###Screenshots
+### Screenshots
 
 
 ![](https://s3.amazonaws.com/f.cl.ly/items/3Z2a3p3G0Z1s071a0536/Image%202015-04-17%20at%202.31.47%20PM.png)
 
 This is a simple demo of our [new WebGL support](https://github.com/servo/servo/pull/5652).
 
-###Meetings
+### Meetings
 
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2015-04-13)
 

--- a/_posts/2015-05-14-twis-32.md
+++ b/_posts/2015-05-14-twis-32.md
@@ -16,7 +16,7 @@ The [Rust upgrade of doom](https://github.com/servo/servo/pull/5935) is finally 
 
 Firefox Nightly now has [experimental support for components written in Rust](https://twitter.com/rillian/status/597150813639684096). There's a patch up to [use Servo's URL parser](https://bugzilla.mozilla.org/show_bug.cgi?id=1151899), and another team is working on media libraries.
 
-###Notable additions
+### Notable additions
 
 - WebGL now supports [actually drawing stuff](https://github.com/servo/servo/pull/5820).
 - We merged [basic WebSockets support](https://github.com/servo/servo/pull/5939) thanks to a NCSU student team!
@@ -34,7 +34,7 @@ Firefox Nightly now has [experimental support for components written in Rust](ht
 - Dhananjay Nakrani [contributed `./mach grep`](https://github.com/servo/servo/pull/5842) for speedy searching of the Servo tree.
 - We started moving Servo's tests [into the wpt infrastructure](https://github.com/servo/servo/pull/5880).
 
-###New contributors
+### New contributors
 
 - Emilio Cobos Álvarez
 - Allen Chen
@@ -47,7 +47,7 @@ Firefox Nightly now has [experimental support for components written in Rust](ht
 - Jacob Taylor-Hindle
 - Shivaji Vidhale
 
-###Screenshots
+### Screenshots
 
 Having previously conquered
 [rectangles](http://blog.servo.org/2015/04/23/twis-31/#screenshots), Servo's
@@ -55,7 +55,7 @@ WebGL engine is now capable of drawing a triangle *inside* a rectangle:
 
 ![](https://cloud.githubusercontent.com/assets/39342/7313736/e3fdb41e-ea11-11e4-8c63-78523cd9dcc7.png)
 
-###Meetings
+### Meetings
 
 We've switched from Critic to [Reviewable](http://reviewable.io/) and it's working pretty well.
 

--- a/_posts/2015-05-28-twis-33.md
+++ b/_posts/2015-05-28-twis-33.md
@@ -21,7 +21,7 @@ Josh [discussed Servo and Rust](https://www.youtube.com/watch?v=87SfA1sw7vY) at 
 We have an impending [upgrade of the SpiderMonkey Javascript engine](https://github.com/servo/servo/pull/6150) by Michael Wu. This moves us from a very old spidermonkey to a recent-ish one. Naturally, the team is quite excited about the prospect
 of getting rid of all the old bugs and getting shiny new ones in their place.
 
-###Notable additions
+### Notable additions
  - We landed a [tiny Rust upgrade](https://github.com/servo/servo/pull/6151) that caused a lot of trouble for its size. Shortly after, we landed [another tiny one](https://github.com/servo/servo/pull/6155) that brought us to 1.2.0
  - Corey [found a bug in `rust-url`](https://github.com/servo/rust-url/pull/108) using [afl.rs](https://github.com/kmcallister/afl.rs), a fuzzer for Rust by Keegan. It's had quite a few success stories so far, try it out on your own project!
  - Patrick [improved support for incremental reflow](https://github.com/servo/servo/pull/6124)
@@ -35,7 +35,7 @@ of getting rid of all the old bugs and getting shiny new ones in their place.
  - Glenn [fixed a bunch of race conditions with reftests and the compositor](https://github.com/servo/servo/pull/6031)
  - James [improved our web platform tests integration to allow for upstreaming binary changes](https://github.com/servo/servo/pull/6036)
 
-###New contributors
+### New contributors
 
  - [Alexander Putilin](https://github.com/eleweek)
  - [Daniel Piros](https://github.com/WriterOfAlicrow)
@@ -44,13 +44,13 @@ of getting rid of all the old bugs and getting shiny new ones in their place.
  - [Kevin Butler](https://github.com/Ryman)
  - [Rohin Patel](https://github.com/r0e)
 
-###Screenshots
+### Screenshots
 
 ![Hebrew Wikipedia in servo-shell](https://pbs.twimg.com/media/CFZBfsEUkAE1f5T.png:large)
 
 This shows off the [CSS `direction`](https://github.com/servo/servo/pull/6138) property. [RTL text still needs some work](https://twitter.com/mbrubeck/status/600739613511028736)
 
-###Meetings
+### Meetings
 
 [Minutes](https://github.com/servo/servo/wiki/Meeting-2015-05-18)
 

--- a/_posts/2015-09-21-twis-34.md
+++ b/_posts/2015-09-21-twis-34.md
@@ -26,7 +26,7 @@ It's been a long time! In the 16 weeks since the last "This Week in Servo," we h
 
 Progress is amazing, and we apologize for the hiatus in this post!
 
-###New Contributors 
+### New Contributors 
 
 Wow - 64 new contributors (4 per week)!
 
@@ -93,10 +93,10 @@ Wow - 64 new contributors (4 per week)!
  - [Xiao Chuan Yu](https://github.com/xiaochuanyu)
  - [Yoav Alon](https://github.com/yoava333)
 
-###Screenshots
+### Screenshots
 
 [Github](https://twitter.com/pcwalton/status/633411771617832961), looking nearly pixel-perfect!
 
-###Meetings
+### Meetings
 
 All of the minutes of the (many!) missed meetings are available [here](https://github.com/servo/servo/wiki/Meetings).

--- a/_posts/2015-09-28-twis-35.md
+++ b/_posts/2015-09-28-twis-35.md
@@ -16,11 +16,11 @@ In addition to a [rustup](https://github.com/servo/servo/pull/7697) by Manish an
 - Martin Robinson landed the [first bits](https://github.com/servo/servo/pull/7710) of his massive ongoing
 stacking context / display list refactoring work
 
-###New Contributors
+### New Contributors
 
  - [Anthony Broad-Crawford](https://github.com/AnthonyBroadCrawford)
 
-###Screenshots
+### Screenshots
 
 Servo on Windows! Courtesy of [Vladimir Vukicevic](http://github.com/vvuk).
 
@@ -30,7 +30,7 @@ Text shaping improvements in Servo:
 
 ![Text shaping improvements](https://pbs.twimg.com/media/CQA13jpVAAA9QHr.png:large)
 
-###Meetings
+### Meetings
 
 At last week's [meeting](https://github.com/servo/servo/wiki/Meeting-2015-09-21), we discussed the outcomes from
 the Paris layout meetup, how to approach submodule updates, and trying to reduce the horrible enlistment experience

--- a/_posts/2015-10-05-twis-36.md
+++ b/_posts/2015-10-05-twis-36.md
@@ -14,7 +14,7 @@ Glenn wrote a short [report](https://github.com/glennw/webrender/wiki) on how we
 along. Webrender is a new renderer for Servo which is specialized for web content. The initial
 results are quite promising!
 
-###Notable additions
+### Notable additions
 
  - Patrick and Corey  reduced allocator churn [in our DOMstring code](https://github.com/servo/servo/pull/7765) [and string joining code](https://github.com/servo/servo/pull/7776)
  - Josh [restyled `<select>`](https://github.com/servo/servo/pull/7847) so that `<select multiple>` works.
@@ -23,18 +23,18 @@ results are quite promising!
  - Martin [simplified our stacking context creation code](https://github.com/servo/servo/pull/7804)
 
 
-###New Contributors
+### New Contributors
 
  - [Nicolas Ouellet-Payeur](https://github.com/6112)
  - [zetok](https://github.com/zetok)
 
-###Screenshots
+### Screenshots
 
 Snazzy new form widgets:
 
 ![](https://cloud.githubusercontent.com/assets/27658/10269411/ec1b5bce-6aa4-11e5-8ce8-0f22425ea3d4.png)
 
-###Meetings
+### Meetings
 
 At last week's [meeting](https://github.com/servo/servo/wiki/Meeting-2015-09-28), we discussed
 [webrender](https://github.com/glennw/webrender), and pulling app units out into a separate crate.

--- a/_posts/2015-10-12-twis-37.md
+++ b/_posts/2015-10-12-twis-37.md
@@ -10,7 +10,7 @@ categories:
 In the [last week](https://github.com/pulls?q=is%3Apr+is%3Amerged+closed%3A2015-10-05..2015-10-12+user%3Aservo),
 we landed 99 PRs in the Servo organization's repositories!
 
-###Notable additions
+### Notable additions
 
  - iawaknahc implemented a [quota for local & session storage](https://github.com/servo/servo/pull/7835)
  - Pretty painless [rust update](https://github.com/servo/servo/pull/7837)
@@ -18,7 +18,7 @@ we landed 99 PRs in the Servo organization's repositories!
  - mbrubeck moved us off of libpng and stb_image for [pure Rust versions](https://github.com/servo/servo/pull/7933)
  - Alex Crichton fixed [spurious rebuilds of the script crate](https://github.com/servo/servo/pull/7936)
 
-###New Contributors
+### New Contributors
 
  - [Alex Crichton](https://github.com/alexcrichton)
  - [Andriy Kunitsin](https://github.com/kunitsyn)
@@ -31,7 +31,7 @@ we landed 99 PRs in the Servo organization's repositories!
  - [Rahul Sharma](https://github.com/creativcoder)
 
 
-###Meetings
+### Meetings
 
 At last week's [meeting](https://github.com/servo/servo/wiki/Meeting-2015-10-05), we discussed
 Browser.html, WebRender, Q4 planning, and our new hire, Alan Jeffrey!

--- a/_posts/2015-10-19-twis-38.md
+++ b/_posts/2015-10-19-twis-38.md
@@ -14,7 +14,7 @@ a heavy stress test of our Rust<->JavaScript integration.
 In the [last week](https://github.com/pulls?page=1&q=is%3Apr+is%3Amerged+closed%3A2015-10-12..2015-10-19+user%3Aservo),
 we landed 82 PRs in the Servo organization's repositories. Additionally, we passed 5,000 stars on https://github.com/servo/servo!
 
-###Notable additions
+### Notable additions
 
  - jdm added a [description of our directories and most important dependencies](https://github.com/servo/servo/pull/8054), with help from ms2ger
  - frewsxcv moved some of our [old ref tests](https://github.com/servo/servo/pull/8045) to the new WPT harness
@@ -23,14 +23,14 @@ we landed 82 PRs in the Servo organization's repositories. Additionally, we pass
  heap `JS<T>` pointers dereferencable](https://github.com/servo/servo/pull/8060) 
  - nox also [moved manual Derived impls to codegen](https://github.com/servo/servo/pull/8020) 
 
-###New Contributors
+### New Contributors
 
  - [Dongie Agnir](https://github.com/dagnir)
  - [Kalpesh Krishna](https://github.com/martiansideofthemoon)
  - [Stephen Li](https://github.com/sliz1)
  - [Tareq A Khandaker](https://github.com/tareqak)
 
-###Meetings
+### Meetings
 
 At last week's [meeting](https://github.com/servo/servo/wiki/Meeting-2015-10-12), we discussed Mozlando meetings, an update
 to our official governance, and the building backlog on our review queue.

--- a/_posts/2015-10-26-twis-39.md
+++ b/_posts/2015-10-26-twis-39.md
@@ -16,7 +16,7 @@ PRs and we're looking forward to burdening them with even more in the future!
 [Michael Wu](https://github.com/michaelwu/), the originator of our Gonk port (aka, Boot2Servo) and frequent hacker on our SpiderMonkey integration,
 has also been granted reviewer priviledges.
 
-###Notable additions
+### Notable additions
 
  - Paul Rouget added a wonderful [quickstart hacking document](https://github.com/servo/servo/pull/8165) to the repo to help with onboarding first-time contributors
  - Florian Merz [implemented a caret](https://github.com/servo/servo/pull/7761) for textarea elements
@@ -26,7 +26,7 @@ has also been granted reviewer priviledges.
  - Anthony Ramine [brought URL-related interfaces and tests](https://github.com/servo/servo/pull/8008) up to spec
  - Eli Friedman [added support](https://github.com/servo/servo/pull/7951) for `whitespace: pre-wrap` and `whitespace: pre-line`
 
-###New Contributors
+### New Contributors
 
  - [Adam Szopa](https://github.com/Darktori)
  - [Florian Merz](https://github.com/fiji-flo)
@@ -34,7 +34,7 @@ has also been granted reviewer priviledges.
  - [Leo Lahti](https://github.com/TileHalo)
  - [nxnfufunezn](https://github.com/nxnfufunezn)
 
-###Meetings
+### Meetings
 
 At last week's [meeting](https://github.com/servo/servo/wiki/Meeting-2015-10-19), we discussed Are We Fast Yet support, DOM feature
 breakdowns, and iframe regressions.

--- a/_posts/2015-11-02-twis-40.md
+++ b/_posts/2015-11-02-twis-40.md
@@ -10,7 +10,7 @@ categories:
 In the [last week](https://github.com/pulls?page=1&q=is%3Apr+is%3Amerged+closed%3A2015-10-26..2015-11-02+user%3Aservo),
 we landed 97 PRs in the Servo organization's repositories.
 
-###Notable additions
+### Notable additions
 
  - Emily Dunham and jdm did [some](https://github.com/servo/servo.org/pull/3) [work](https://github.com/servo/servo-starters/pull/9) getting http://servo.org/starters working!
  - Manish added support for [`@bors-servo: try`](https://github.com/servo/saltfs/pull/141) for people who don't have full reviewer priviledges in Servo
@@ -19,12 +19,12 @@ we landed 97 PRs in the Servo organization's repositories.
  - Till cleaned up our [script loading and execution](https://github.com/servo/servo/pull/7979)
  - David Zbarsky added more `calc` expressions in [CSS](https://github.com/servo/servo/pull/7400)
 
-###New Contributors
+### New Contributors
 
 -  [Axel Solis Trompler](https://github.com/ax3lst)
  - [Nova Fallen](https://github.com/nfallen)
 
-###Meetings
+### Meetings
 
 At last week's [meeting](https://github.com/servo/servo/wiki/Meeting-2015-10-26), we discussed WebRender, automated testing, ipc-channel fallthroughs, and DOM invalidation changes.
 

--- a/_posts/2015-11-09-twis-41.md
+++ b/_posts/2015-11-09-twis-41.md
@@ -12,7 +12,7 @@ we landed 129 PRs in the Servo organization's repositories!
 
 James Graham, a long-time Servo contributor who has been one of the main architects of our testing strategy, now has [reviewer privileges](https://github.com/servo/saltfs/pull/153). No good deed goes unpunished!
 
-###Notable additions
+### Notable additions
 
  - Patrick Walton reduced the number of spurious [reflows](https://github.com/servo/servo/pull/8299) and [compositor events](https://github.com/servo/servo/pull/8300)
  - Alan Jeffrey got us a huge SpiderMonkey speed boost by [using](https://github.com/servo/rust-mozjs/pull/210) `nativeRegExp`
@@ -23,7 +23,7 @@ James Graham, a long-time Servo contributor who has been one of the main archite
  - Matt Brubeck and [others](https://github.com/servo/rust-mozjs/pull/211) have been working on [cleaning](https://github.com/servo/rust-fontconfig/pull/30) [the](https://github.com/servo/cgl-rs/pull/13) [libcpocalypse](https://github.com/servo/io-surface-rs/pull/42)
  - Lars changed how the [Android build](https://github.com/servo/servo/pull/8288) works, so that now we can have a custom icon, Java code for handling intents, and debug
 
-###New Contributors
+### New Contributors
 
  - [Abhishek Kumar](https://github.com/akumar21NCSU)
  - [Benjamin Herr](https://github.com/ben0x539)
@@ -35,7 +35,7 @@ James Graham, a long-time Servo contributor who has been one of the main archite
  - [Ulysse Carion](https://github.com/ucarion)
  - [jsharda](https://github.com/Ronak6892)
 
-###Meetings
+### Meetings
 
 At last week's [meeting](https://github.com/servo/servo/wiki/Meeting-2015-11-02), we discussed review carry-over, test coverage, the 2016 roadmap, rebase/autosquash for the autolander, the overwhelming PR queue, debug logging, and the CSSWG reftests.
 

--- a/_posts/2015-11-16-twis-42.md
+++ b/_posts/2015-11-16-twis-42.md
@@ -16,7 +16,7 @@ Prabhjyot Sodhi did some initial analysis of Servo's E-Easy bugs to show how lon
 ![](http://i.imgur.com/fE6PcS8.png)
 ![](http://i.imgur.com/baDkWZ1.png)
 
-###Notable additions
+### Notable additions
 
  - SimonSapin [added](https://github.com/servo/servo/pull/8520) a `./mach run --android` to help ease the new Android developer experience
  - rillian [fixed](https://github.com/servo/servo/pull/8517) our placeholder image
@@ -31,12 +31,12 @@ Prabhjyot Sodhi did some initial analysis of Servo's E-Easy bugs to show how lon
  - waffles [made](https://github.com/servo/servo/pull/7844) network requests cancellable.
  - Emilio Cobos Álvarez [implemented](https://github.com/servo/servo/pull/8412) WebIDL sequence type return values.
 
-###New Contributors
+### New Contributors
 
  - [Ralph Gilles](https://github.com/rillian)
  - [Rizky Luthfianto](https://github.com/rilut)
  - [Lucy Wyman](https://github.com/lucywyman)
 
-###Meetings
+### Meetings
 
 At last week's [meeting](https://github.com/servo/servo/wiki/Meeting-2015-11-09), we discussed our GitHub subproject handling, the new servo.org webpage, multi-repo workflows, and the revival of our Rust-tracking-bug.

--- a/_posts/2015-11-30-twis-43.md
+++ b/_posts/2015-11-30-twis-43.md
@@ -14,7 +14,7 @@ The huge news from the last two weeks is that after some really serious efforts 
 
 Now that we have separate support for making `try` builds, we have added dzbarsky, ecoal95, KiChjang, ajeffrey, and waffles. Please nominate your local friendly contributor today!
 
-###Notable additions
+### Notable additions
 
  - notriddle [made](https://github.com/servo/servo/pull/8538) GitHub look better
  - ms2ger [ran](https://github.com/servo/servo/pull/8569) rustfmt and began cleaning up our code
@@ -32,7 +32,7 @@ Now that we have separate support for making `try` builds, we have added dzbarsk
  - kichjang [provided](https://github.com/servo/servo/pull/8609) MIME types for file:// URLs
  - pcwalton [split](https://github.com/servo/servo/pull/8599) the engine into multiple sandboxed processes
 
-###New Contributors
+### New Contributors
 
 - [Aleksandr Likhanov](https://github.com/vegayours)
 - [Alex Gaynor](https://github.com/alex)
@@ -45,13 +45,13 @@ Now that we have separate support for making `try` builds, we have added dzbarsk
 - [Yanir Seroussi](https://github.com/yanirs)
 - [jmr0](https://github.com/jmr0)
 
-###Screenshots
+### Screenshots
 
 Screencast of this post being submitted to Hacker News:
 
 ![(screencast)](https://cloud.githubusercontent.com/assets/1617736/11486909/fa1e9686-97e1-11e5-8c7c-c36ce3ac26d1.gif)
 
 
-###Meetings
+### Meetings
 
 At the [meeting](https://github.com/servo/servo/wiki/Meeting-2015-11-16) two weeks ago we discussed intermittent test failures, using a mailing lists vs. discourse, the libcpocalypse, and our E-Easy issues. There was no meeting last week.

--- a/_posts/2015-12-21-twis-44.md
+++ b/_posts/2015-12-21-twis-44.md
@@ -13,7 +13,7 @@ In a particularly epic display of tenacity, imperio [landed](https://github.com/
 
 There were two major Servo-related blog posts in the past weeks. One is by Mike Blumenkrantz (zmike) [covering](http://blogs.s-osg.org/community-driven-wayland-support-servo/) his Wayland port of Servo. The second is by Patrick Walton (pcwalton) [discussing](http://pcwalton.github.io/blog/2015/12/21/drawing-css-box-shadows-in-webrender/) his implementation of CSS Box Shadows in our prototype painting engine, WebRender.
 
-###Notable Additions
+### Notable Additions
 
 - mbrubeck [added](https://github.com/servo/servo/pull/9020) the ability for `mach run` on Android to browse to a URL properly
 - mwu [implemented](https://github.com/servo/rust-mozjs/pull/225) a `CustomAutoRooter` in the JS bindings
@@ -24,7 +24,7 @@ There were two major Servo-related blog posts in the past weeks. One is by Mike 
 - paulrouget [added](https://github.com/servo/servo/pull/8886) support for freezing old iframes after navigation
 
 
-###New Contributors
+### New Contributors
 
 - [Alexander Mankuta](https://github.com/cheba)
 - [Arnaud Marant](https://github.com/amarant)
@@ -42,11 +42,11 @@ There were two major Servo-related blog posts in the past weeks. One is by Mike 
 - [Ken](https://github.com/k-cross)
 - [Ronak Nisher](https://github.com/ronaknisher)
 
-###Screenshots
+### Screenshots
 
 None this week.
 
-###Meetings
+### Meetings
 
 At the [meeting](https://github.com/servo/servo/wiki/Meeting-2015-11-30) three weeks ago, we discussed planning topics for Mozlando, the NCSU projects, and crate squatting issues.
 

--- a/_posts/2015-12-28-twis-45.md
+++ b/_posts/2015-12-28-twis-45.md
@@ -12,20 +12,20 @@ In the [last week](https://github.com/pulls?page=1&q=is%3Apr+is%3Amerged+closed%
 This week brings us some of the first progress on Stylo, which is an effort to make it possible to use Servo's style system within Firefox/Gecko.
 
 
-###Notable Additions
+### Notable Additions
 
 - ecoal [added](https://github.com/servo/saltfs/pull/182) support for running Servo's WebGL on Linux over EGL instead of GLX
 - bholley [landed](https://github.com/servo/servo/pull/9004) the first set of Stylo support in Servo
 
-###New Contributors
+### New Contributors
 
 - [Daan Sprenkels](https://github.com/dsprenkels)
 - [Joe Kachmar](https://github.com/jkachmar)
 
-###Screenshots
+### Screenshots
 
 None this week.
 
-###Meetings
+### Meetings
 
 All were cancelled, given the holiday breaks.

--- a/_posts/2016-01-04-twis-46.md
+++ b/_posts/2016-01-04-twis-46.md
@@ -11,7 +11,7 @@ In the [last week](https://github.com/pulls?page=1&q=is%3Apr+is%3Amerged+closed%
 
 This week, edunham [moved](https://github.com/servo/saltfs/pull/183) us onto our own EC2 account for our CI, which will bring us both more reliability (our automation was "fighting" for instances with another team's) and allowed us to remove some of most expensive fallback instances.
 
-###Notable Additions
+### Notable Additions
 
 - Simon [renamed](https://github.com/servo/servo/pull/9086) the `rust-snapshot-hash` file to `rust-nightly-date`
 - larsberg [fixed](https://github.com/servo/blog.servo.org/pull/51) the long-broken TWiS RSS feed
@@ -19,7 +19,7 @@ This week, edunham [moved](https://github.com/servo/saltfs/pull/183) us onto our
 - jdm [made](https://github.com/servo/servo/pull/8109) button elements activateable, fixing reddit and github 2fa issues
 - bholley [split](https://github.com/servo/servo/pull/9051) the layout wrappers up more, in support of the Stylo work
 
-###New Contributors
+### New Contributors
 
 - [Adrian Heine né Lang](https://github.com/adrianheine)
 - [Alberto Corona](https://github.com/0X1A)
@@ -27,10 +27,10 @@ This week, edunham [moved](https://github.com/servo/saltfs/pull/183) us onto our
 - [Iszak Bryan](https://github.com/iszak)
 - [Johannes Linke](https://github.com/karyon)
 
-###Screenshots
+### Screenshots
 
 None this week.
 
-###Meetings
+### Meetings
 
 All were cancelled again, due to the New Year holiday.

--- a/_posts/2016-01-11-twis-47.md
+++ b/_posts/2016-01-11-twis-47.md
@@ -13,7 +13,7 @@ We are very excited to announce that we've [added](https://github.com/servo/salt
 
 With the start of 2016, we've [updated](https://github.com/servo/servo/wiki/Roadmap) Servo's roadmap. You can also [see](https://public.etherpad-mozilla.org/p/Servo-Q1-2016) our team Q1 goal planning in progress. 2016 looks to be a very exciting year for the project!
 
-###Notable Additions
+### Notable Additions
 
 - bholley [landed](https://github.com/servo/servo/pull/9209) a `geckolib` target, which is basically a subset of Servo's style system for reuse in Gecko
 - nox [enabled](https://github.com/servo/servo/issues/2665) a ton more tests by fixing up the proto chains of interface objects
@@ -22,7 +22,7 @@ With the start of 2016, we've [updated](https://github.com/servo/servo/wiki/Road
 - craftytricker [eliminated](https://github.com/servo/servo/pull/8860) the need to clone the underlying buffer when slicing a Blob
 
 
-###New Contributors
+### New Contributors
 
 - [Fernando Martins](https://github.com/fmmartins)
 - [Geoffrey Sneddon](https://github.com/gsnedders)
@@ -32,10 +32,10 @@ With the start of 2016, we've [updated](https://github.com/servo/servo/wiki/Road
 - [Thomas Gummerer](https://github.com/tgummerer)
 - [Ying-Ruei Liang (KK)](https://github.com/TheKK)
 
-###Screenshots
+### Screenshots
 
 None this week.
 
-###Meetings
+### Meetings
 
 We had a [meeting](https://github.com/servo/servo/wiki/Meeting-2016-01-04) on thesis topics, automake, layout refactoring, the SM upgrade, and code review on prototypes.


### PR DESCRIPTION
e.g. https://servo.org/blog/2014/09/01/twis-1/

![image](https://user-images.githubusercontent.com/465303/212076184-ffdd6f8a-e566-45e9-b648-4cabc25e8ff7.png)

used vscode replace as follows:

* find `^(#+)([^ #])`
* replace `$1 $2`
* in `_posts/`