### PR TITLE
Integrate download.servo.org into the website

### DIFF
--- a/_data/downloads.json
+++ b/_data/downloads.json
@@ -1,25 +1,30 @@
 [
   {
+    "key": "windows-exe",
     "name": "Windows EXE",
     "href": "nightly/windows-msvc/servo-latest.exe",
     "sha256": "nightly/windows-msvc/servo-latest.exe.sha256"
   },
   {
+    "key": "windows-zip",
     "name": "Windows ZIP",
     "href": "nightly/windows-msvc/servo-latest.zip",
     "sha256": "nightly/windows-msvc/servo-latest.zip.sha256"
   },
   {
+    "key": "uwp",
     "name": "UWP (arm64/x64)",
     "href": "nightly/uwp/servo-latest.zip",
     "sha256": "nightly/uwp/servo-latest.zip.sha256"
   },
   {
+    "key": "mac",
     "name": "macOS (x64)",
     "href": "nightly/mac/servo-latest.dmg",
     "sha256": "nightly/mac/servo-latest.dmg.sha256"
   },
   {
+    "key": "linux",
     "name": "Linux (x64)",
     "href": "nightly/linux/servo-latest.tar.gz",
     "sha256": "nightly/linux/servo-latest.tar.gz.sha256"

--- a/_data/menu.json
+++ b/_data/menu.json
@@ -2,5 +2,6 @@
   { "title": "How to start", "url": "https://github.com/servo/servo/blob/master/docs/HACKING_QUICKSTART.md" },
   { "title": "Contributing", "url": "https://github.com/servo/servo/blob/master/CONTRIBUTING.md" },
   { "title": "Blog", "url": "/blog/" },
-  { "title": "Governance", "url": "/governance/" }
+  { "title": "Governance", "url": "/governance/" },
+  { "title": "Download", "url": "/download/" }
 ]

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,34 +1,87 @@
-<section class="section">
-  <div class="container">
-    <div class="content">
-      <h2 id="download">
-        Downloads
-        <a class="headline-hash" href="#download">
-          <span class="icon hashlink">
-            <i class="fas fa-link"></i>
-          </span>
-        </a>
-      </h2>
-      <p>
-        These pre-built nightly snapshots allow developers to try Servo and
-        <a href="https://github.com/servo/servo/issues/new">report issues</a>
-        without building Servo locally. Please don’t log into your bank with
-        Servo just yet! Now that we’ve released our first developer preview,
-        we’ll be investing in formal security audits and improving our security
-        practices using both existing libraries and Rust – more information
-        coming soon!
-      </p>
-      <div class="downloads">
-        {% for download in downloads %}
+<div class="container">
+  <div class="content">
+    <div class="columns">
+      <div class="column">
         <p>
-          <div class="buttons has-addons">
-            <a class="button is-primary" href="https://download.servo.org/{{download.href}}">{{download.name}}</a>
-            <a class="button" href="https://download.servo.org/{{download.sha256}}">sha256</a>
-          </div>
+          These pre-built nightly snapshots allow developers to try Servo and
+          <a href="https://github.com/servo/servo/issues/new">report issues</a> without
+          <a href="https://github.com/servo/servo/blob/master/docs/HACKING_QUICKSTART.md">building Servo locally</a>.
+          <strong>Please don’t log into your bank with Servo just yet!</strong>
+          Now that we’ve released our first developer preview,
+          we’ll be investing in formal security audits and improving our security
+          practices using both existing libraries and Rust – more information
+          coming soon!
         </p>
-        {% endfor %}
+      </div>
+      <div class="column">
+        <div class="downloads">
+          {% for download in downloads %}
+          <p>
+            <div class="buttons has-addons">
+              <a class="button is-primary" href="https://download.servo.org/{{download.href}}">{{download.name}}</a>
+              <span class="button is-static" id="date-{{download.key}}">?</span>
+              <a class="button" href="https://download.servo.org/{{download.sha256}}">sha256</a>
+            </div>
+          </p>
+          {% endfor %}
+        </div>
       </div>
     </div>
   </div>
-</section>
+</div>
+<script type="text/javascript">
+  window.onload = load_build_info;
 
+  function load_build_info() {
+      var builds = [
+        {% for download in downloads %}
+          ["{{ download.key }}", "{{ download.href }}" ],
+        {% endfor %}
+      ];
+
+      builds.forEach(function (item, index) {
+          load_build_date("date-" + item[0], item[1]);
+      });
+  }
+
+  function load_build_date(id, prefix) {
+      var url = "https://servo-builds2.s3.amazonaws.com/?list-type=2&prefix=" + prefix;
+      get_request(url, function (text) {
+          var xml = parse_xml(text);
+          var contents_tag = xml.getElementsByTagName("Contents")[0];
+          var last_modified_tag = contents_tag.getElementsByTagName("LastModified")[0];
+
+          var last_modified = last_modified_tag.textContent;
+          var last_modified_date = last_modified.split("T")[0];
+
+          var el = document.getElementById(id);
+          el.innerText = last_modified_date;
+          el.title = last_modified;
+      });
+  }
+
+  function get_request(url, callback) {
+      var xhttp = new XMLHttpRequest();
+      xhttp.onreadystatechange = function () {
+          if (xhttp.readyState == XMLHttpRequest.DONE && xhttp.status == 200) {
+              callback(xhttp.responseText);
+          }
+      };
+      xhttp.open("GET", url, true);
+      xhttp.send();
+  }
+
+  function parse_xml(text) {
+      if (window.DOMParser) {
+          var parser = new DOMParser();
+          var xml_doc = parser.parseFromString(text, "text/xml");
+          return xml_doc;
+      } else {
+          // Internet Explorer
+          var xml_doc = new ActiveXObject("Microsoft.XMLDOM");
+          xml_doc.async = false;
+          xml_doc.loadXML(text);
+          return xml_doc;
+      }
+  }
+</script>

--- a/_includes/home.html
+++ b/_includes/home.html
@@ -12,7 +12,21 @@
           </div>
         </div>
       </section>
-      {% include "downloads.html" %}
+      <section class="section">
+        <div class="container">
+          <div class="content">
+            <h2 id="download">
+              Downloads
+              <a class="headline-hash" href="#download">
+                <span class="icon hashlink">
+                  <i class="fas fa-link"></i>
+                </span>
+              </a>
+            </h2>
+          </div>
+        </div>
+        {% include "downloads.html" %}
+      </section>
     </main>
     {% include "footer.html" %}
   </body>

--- a/assets/sass/content.sass
+++ b/assets/sass/content.sass
@@ -161,3 +161,6 @@ $content-table-foot-cell-color: $text-strong !default
     font-size: $size-large
   .grey-light
     color: $grey-light
+  code
+    color: $servo-green
+


### PR DESCRIPTION
This patch reuses code from download.servo.org to show the date of the last builds.
It removes the current table at download.servo.org, but it seems kind of duplicated with the content above it. It includes the instructions that were present at download.servo.org for macOS and Linux under servo.org/download