### PR TITLE
Upgrade eleventy-plugin-syntaxhighlight to fix HTML syntax highlight issue

### DIFF
--- a/_posts/2023-05-31-adding-support-for-outline-properties.md
+++ b/_posts/2023-05-31-adding-support-for-outline-properties.md
@@ -17,7 +17,7 @@ A few days ago, we landed support for ‘outline’ and ‘outline-offset’. Th
 
 The impact of this feature is most noticeable in the focus styles for links and input fields. For example, the User Agent stylesheet already applies ‘outline: thin dotted’ to ‘a:focus’, so clicking the first link in
 
-```
+```html
 Lorem ipsum <a href="#">dolor sit amet</a>,
 consectetur <a href="#">adipiscing elit</a>.
 ```
@@ -44,7 +44,7 @@ The spec allows outlines to be painted either [in-band](https://drafts.csswg.org
 
 For example, the magenta element below overlaps the blue border of the previous element, but not the out-of-band cyan outline:
 
-```
+```html
 <div style="
     outline: 5px solid cyan;
     border: 5px solid blue;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@11ty/eleventy": "^1.0.2",
     "@11ty/eleventy-plugin-rss": "^1.2.0",
-    "@11ty/eleventy-plugin-syntaxhighlight": "^4.2.0",
+    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
     "bulma": "^0.9.0",
     "gh-pages": "^3.0.0",
     "markdown-it-anchor": "^8.6.6",


### PR DESCRIPTION
With upgrading the plugin, we can fix the syntax highlight issue for HTML.

| Before | After |
| --- | --- |
| ![image](https://github.com/servo/servo.org/assets/6782666/385c31a1-08cd-4679-9907-1f3650bd8866) | ![image](https://github.com/servo/servo.org/assets/6782666/73fa036f-4c1a-4632-ac68-5de77dc6cd65) |

---

Fix #96.