### PR TITLE
Small edit to front page header

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,7 +18,7 @@
   <meta property="og:image" content="{{ site.logo | url }}">
   <meta property="og:image:alt" content="Servo logo">
   <meta property="og:logo" content="{{ site.favicon | url }}">
-  <meta property="og:description" content="Servo is a web rendering engine written in Rust, WebGL and WebGPU capable, and adaptable to desktop, mobile, and embedded applications.">
+  <meta property="og:description" content="Servo is a web rendering engine written in Rust, with WebGL and WebGPU support, and adaptable to desktop, mobile, and embedded applications.">
   <meta property="og:url" content="{{ page.url | url  }}">
 
   <link rel="stylesheet" href="{{ '/css/style.css' | url }}">


### PR DESCRIPTION
This removes the ambiguity between:

- Servo is written with Rust, WebGL, and WebGPU
- Servo is written with Rust and has support for WebGL and WebGPU

I'm not attached to this wording, so feel free to suggest anything else that removes the ambiguity.