### PR TITLE
download: add link to nightly apk builds

### DIFF
--- a/_data/downloads.json
+++ b/_data/downloads.json
@@ -22,5 +22,11 @@
     "name": "Linux (x64)",
     "href": "nightly/linux/servo-latest.tar.gz",
     "sha256": "nightly/linux/servo-latest.tar.gz.sha256"
+  },
+  {
+    "key": "android-aarch64-apk",
+    "name": "Android (aarch64)",
+    "href": "nightly/android/servo-latest.apk",
+    "sha256": "nightly/android/servo-latest.apk.sha256"
   }
 ]

--- a/_includes/downloads-list.html
+++ b/_includes/downloads-list.html
@@ -2,7 +2,7 @@
   {% for download in downloads %}
   <p>
     <div class="buttons has-addons">
-      <a rel="nofollow" role="button" class="button is-primary" href="https://download.servo.org/{{download.href}}" style="width: 15ch;">{{download.name}}</a>
+      <a rel="nofollow" role="button" class="button is-primary" href="https://download.servo.org/{{download.href}}" style="width: 20ch;">{{download.name}}</a>
       <span class="button is-static" id="date-{{download.key}}" style="width: 12ch;">?</span>
       <a rel="nofollow" role="button" class="button" href="https://download.servo.org/{{download.sha256}}">sha256</a>
     </div>


### PR DESCRIPTION
The cloudflare configuration has been updated with bulk redirects for 

download.servo.org/nightly/android/servo-latest.apk
download.servo.org/nightly/android/servo-latest.apk.sha256
download.servo.org/nightly/android/servo-latest.aar 
download.servo.org/nightly/android/servo-latest.aar.sha256

I'm only exposing the APK in this PR. Not sure if we also want to expose the AAR now, or wait until there is demand for it to be available from servo.org.

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>
