### PR TITLE
downloads: add links for OpenHarmony nightly

### DIFF
--- a/_data/downloads.json
+++ b/_data/downloads.json
@@ -28,5 +28,11 @@
     "name": "Android (aarch64)",
     "href": "nightly/android/servo-latest.apk",
     "sha256": "nightly/android/servo-latest.apk.sha256"
+  },
+  {
+    "key": "ohos-aarch64-hap",
+    "name": "OpenHarmony (aarch64)",
+    "href": "nightly/ohos/servo-latest.hap",
+    "sha256": "nightly/ohos/servo-latest.hap.sha256"
   }
 ]

--- a/_includes/downloads-list.html
+++ b/_includes/downloads-list.html
@@ -2,8 +2,8 @@
   {% for download in downloads %}
   <p>
     <div class="buttons has-addons">
-      <a rel="nofollow" role="button" class="button is-primary" href="https://download.servo.org/{{download.href}}" style="width: 17ch;">{{download.name}}</a>
-      <span class="button is-static" id="date-{{download.key}}" style="width: 12ch;">?</span>
+      <a rel="nofollow" role="button" class="button is-primary" href="https://download.servo.org/{{download.href}}" style="width: 22ch;">{{download.name}}</a>
+      <span class="button is-static" id="date-{{download.key}}" style="width: 10ch;">?</span>
       <a rel="nofollow" role="button" class="button" style="width: 7ch;" href="https://download.servo.org/{{download.sha256}}">sha256</a>
     </div>
   </p>


### PR DESCRIPTION
I've added the necessary redirection rules in cloudformation. I've also tested the changes here on my mobile and the download buttons do seem to have the correct width, but let me know if things seem broken on your mobile.