### PR TITLE
Add link to this repo to website footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,6 +6,7 @@
         <p>&copy; {% currentYear %} {{ site.author }}</p>
         <p>Copyright &copy; Servo is a project of <a class="footer-link" href="https://linuxfoundation.eu/">Linux Foundation Europe</a>.</p>
         <p>For website terms of use, trademark policy and other project policies please see <a class="footer-link" href="https://lfprojects.org">https://lfprojects.org</a>.</p>
+        <p>The source code for this website can be found at <a class="footer-link" href="https://github.com/servo/servo.org">https://github.com/servo/servo.org</a>.</p>
       </div>
       <div class="column code-of-conduct">
         <a class="footer-link" href="{{ '/coc/' | url }}">Code of Conduct</a>


### PR DESCRIPTION
This is for people wanting to contribute to the Servo website itself to help them easily find the repo (it's also for me because there are a *lot* of things that autocomplete when I type "servo" so navigating to this repo can be kinda annoying).