### PR TITLE
Remove YouTube video

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -12,11 +12,7 @@
     </div>
     <div class="gradient-back">
       <img src="{{ '/img/home-servo-hero.png' | url }}" alt="" />
-      <div class="column" style="display: none;">
-        <iframe style="width: 100%; aspect-ratio: 560/315;" src="https://www.youtube.com/embed/mMTwQUKL288" title="Servo Project Updates at Linux Foundation Europe Member Summit 2024 by Manuel Rego" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-        </video>
-      </div>
-    </div>  
+    </div>
   </div>
   <div class="container">
     <p class="subtitle center-text cta-text">


### PR DESCRIPTION
We're not using it as it has "display: none" so we can remove it.