### PR TITLE
downloads: switch the url for linux nightlies.

### DIFF
--- a/_data/downloads.json
+++ b/_data/downloads.json
@@ -26,8 +26,8 @@
   {
     "key": "linux",
     "name": "Linux (x64)",
-    "href": "nightly/linux/servo-latest.tar.gz",
-    "sha256": "nightly/linux/servo-latest.tar.gz.sha256"
+    "href": "nightly/linux/servo-x86_64-linux-gnu.tar.gz",
+    "sha256": "nightly/linux/servo-x86_64-linux-gnu.tar.gz.sha256"
   },
   {
     "key": "android-aarch64-apk",


### PR DESCRIPTION
We have an upper limit on the number of redirections setup in CF, so we switch the platforms gradually and allow the old links to work while the new links are rolled out.