### PR TITLE
Remove box shadow and update border and focus visible styles

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -6,8 +6,8 @@
         Servo aims to empower developers with a lightweight, high-performance alternative for embedding web technologies in applications.
       </h1>
       <div class="center-text cta-container">
-        <a class="button button--hero" href="/contributing/">Get Involved</a>
-        <a class="button button--hero" target="_blank" href="https://opencollective.com/servo">Donate</a>
+        <a class="button--hero" href="/contributing/">Get Involved</a>
+        <a class="button--hero" target="_blank" href="https://opencollective.com/servo">Donate</a>
       </div>
     </div>
     <div class="gradient-back">

--- a/assets/css/style.css.liquid
+++ b/assets/css/style.css.liquid
@@ -750,15 +750,12 @@ table {
   display: inline-flex;
   font-size: 1rem;
   height: 2.5em;
-  justify-content: flex-start;
   line-height: 1.5;
   position: relative;
   vertical-align: top;
   padding: 1.25rem .75rem;
 
-
   background-color: var(--midturquoise);
-  box-shadow: 0 0 1px 1px  hsl(0, 0%, 86%);
   color: hsl(0, 0%, 100%);
   cursor: pointer;
   justify-content: center;
@@ -770,26 +767,23 @@ table {
   -moz-appearance: none;
   -webkit-appearance: none;
   align-items: center;
-  border: 1px solid transparent;
-  border-radius: 24px;
+  color: hsl(0, 0%, 100%);
+  border-radius: 44px;
   box-shadow: none;
   display: inline-flex;
   font-size: 1.25rem;
   height: 2.5em;
-  justify-content: flex-start;
   line-height: 1.5;
   position: relative;
   vertical-align: top;
   padding: 1.25rem 1.5rem;
 
-
   background-color: var(--midturquoise);
-  box-shadow: 0 0 1px 1px  hsl(0, 0%, 86%);
-  color: hsl(0, 0%, 100%);
   cursor: pointer;
   justify-content: center;
   text-align: center;
   white-space: nowrap;
+  text-decoration: none;
 }
 
 .button--hero:hover {
@@ -797,9 +791,26 @@ table {
   background-color: var(--darkturquoise);
 }
 
+a.button--hero::after {
+    content: '';
+    position: absolute;
+    text-decoration: none;
+    inset: 0;
+    border-radius: inherit;
+    border: 2px solid hsl(0 0% 100% / 0.4);
+}
+
+
+:is(a,button):focus-visible,
+a.button--hero:focus-visible {
+  outline-offset: 3px;
+  outline: 3px solid var(--darkturquoise);
+}
+
 .button:focus, .is-focused.button, .button:active, .is-active.button {
   outline: none;
 }
+
 [disabled].button, fieldset[disabled] .button {
   cursor: not-allowed;
 }


### PR DESCRIPTION
Adding a box shadow and removing the border from #256 made the buttons look less crisp. This was due to multiple borders being applied via two different classes and the border-radius not aligning.

I've removed the box shadow, updated focus-visible styles and updated the button border styling. 