### PR TITLE
Add Linux ARM64 nightly to the download page.

### DIFF
--- a/_data/downloads.json
+++ b/_data/downloads.json
@@ -35,6 +35,13 @@
     "sha256": "nightly/linux/servo-x86_64-linux-gnu.tar.gz.sha256"
   },
   {
+    "key": "linux-arm64",
+    "icon": "linux",
+    "name": "Linux (aarch64)",
+    "href": "nightly/linux/servo-aarch64-linux-gnu.tar.gz",
+    "sha256": "nightly/linux/servo-aarch64-linux-gnu.tar.gz.sha256"
+  },
+  {
     "key": "android-aarch64-apk",
     "icon": "android",
     "name": "Android (aarch64)",


### PR DESCRIPTION
I've tested the latest nightly build in servo-nightly-builds repo with rPi 400 & 500. I've also added the URL redirection rule to CF and tested that it works.