### PR TITLE
feat: add dark mode to servo.org site

### DIFF
--- a/_includes/downloads-list.html
+++ b/_includes/downloads-list.html
@@ -49,7 +49,7 @@
 
   .download-item > a > i {
     font-size: 2.5em;
-    color: black;
+    color: var(--text-primary);
   }
 
   .download-item > a > h2 {

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,12 @@
   <div class="container">
     <div class="two-column inner-container">
       <div class="column">
-        <div class="logo"><a href="https://linuxfoundation.eu"><img src="{{ site.logoLFEurope | url }}" alt="Linux Foundation Europe logo" width="250"></a></div>
+        <div class="logo">
+          <a href="https://linuxfoundation.eu">
+            <img class="footer-logo--light" src="{{ site.logoLFEurope | url }}" alt="Linux Foundation Europe logo" width="250">
+            <img class="footer-logo--dark" src="{{ '/img/lf-europe-white.svg' | url }}" alt="Linux Foundation Europe logo" width="250">
+          </a>
+        </div>
         <p>&copy; {% currentYear %} {{ site.author }}</p>
         <p>Copyright &copy; Servo is a project of <a class="footer-link" href="https://linuxfoundation.eu/">Linux Foundation Europe</a>.</p>
         <p>For website terms of use, trademark policy and other project policies please see <a class="footer-link" href="https://lfprojects.org">https://lfprojects.org</a>.</p>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
     (function () {
       try {
         var savedTheme = localStorage.getItem('theme');
-        var systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matchs;
+        var systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         var theme = savedTheme ? savedTheme : (systemPrefersDark ? 'dark' : 'light');
         document.documentElement.setAttribute('data-theme', theme);
       } catch (e) {}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,19 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- Helps with theme detection from ls-->
+  <script>
+    (function () {
+      try {
+        var savedTheme = localStorage.getItem('theme');
+        var systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matchs;
+        var theme = savedTheme ? savedTheme : (systemPrefersDark ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', theme);
+      } catch (e) {}
+    })()
+  </script>
+
   {% if title == "Home" %}
   <title>{{ site.tagline }}</title>
   <meta property="og:title" content="{{ site.tagline }}">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,8 +4,8 @@
       <div class="navbar-brand">
         <a href="{{ '/' | url }}">
           <!-- dark/light logos -->
-          <img class="logo-light" src="{{ site.logoMark | url }" alt="{{ title ">
-          <img class="logo-dark" src="{{ '/svg/servo-color-negative-svg' | url }}" alt="{{ title }}">
+          <img class="logo-light" src="{{ site.logoMark | url }}" alt="{{ title }}">
+          <img class="logo-dark" src="{{ '/svg/servo-color-negative.svg' | url }}" alt="{{ title }}">
         </a>
 
         <button id="hamburgerMenu" class="navbar-burger" data-target="navbar-menu" aria-label="menu" aria-expanded="false" type="button">
@@ -82,7 +82,7 @@
   // Theme switch logic
   const themeToggle = document.getElementById('themeToggle');
   themeToggle?.addEventListener('click', () => {
-    const currentTheme = document.documentElement.getAttribute('dark-theme') ||'light';
+    const currentTheme = document.documentElement.getAttribute('data-theme') ||'light';
     const nextTheme = currentTheme == 'dark' ? 'light' : 'dark';
     document.documentElement.setAttribute('data-theme', nextTheme);
     try{

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,9 @@
     <div class="inner-container">
       <div class="navbar-brand">
         <a href="{{ '/' | url }}">
-          <img src="{{ site.logoMark | url }}" alt="{{ title }}">
+          <!-- dark/light logos -->
+          <img class="logo-light" src="{{ site.logoMark | url }" alt="{{ title ">
+          <img class="logo-dark" src="{{ '/svg/servo-color-negative-svg' | url }}" alt="{{ title }}">
         </a>
 
         <button id="hamburgerMenu" class="navbar-burger" data-target="navbar-menu" aria-label="menu" aria-expanded="false" type="button">
@@ -54,6 +56,12 @@
             </a>
           {% endif %}
         {% endfor %}
+
+        <!-- Theme toggle btn -->
+        <button id="themeToggle" class="theme-toggle-btn" type="button" aria-label="Toggle theme" title="Toggle dark/light mode">
+          <i class="fas fa-moon" aria-hidden="true"></i>
+          <i class="fas fa-sun"></i>
+        </button>
         {% include "social-buttons.html" %}
       </div>
     </div>
@@ -69,9 +77,16 @@
     hamburger.setAttribute('aria-expanded', !isExpanded);
     menu.classList.toggle('is-active', isExpanded);
   };
-
-  // Toggle on click
   hamburger.addEventListener('click', toggleMenu);
 
-
+  // Theme switch logic
+  const themeToggle = document.getElementById('themeToggle');
+  themeToggle?.addEventListener('click', () => {
+    const currentTheme = document.documentElement.getAttribute('dark-theme') ||'light';
+    const nextTheme = currentTheme == 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', nextTheme);
+    try{
+      localStorage.setItem('theme', nextTheme)
+    } catch (e) {}
+  });
 </script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,9 +3,7 @@
     <div class="inner-container">
       <div class="navbar-brand">
         <a href="{{ '/' | url }}">
-          <!-- dark/light logos -->
-          <img class="logo-light" src="{{ site.logoMark | url }}" alt="{{ title }}">
-          <img class="logo-dark" src="{{ '/svg/servo-color-negative.svg' | url }}" alt="{{ title }}">
+          <img src="{{ site.logoMark | url }}" alt="{{ title }}">
         </a>
 
         <button id="hamburgerMenu" class="navbar-burger" data-target="navbar-menu" aria-label="menu" aria-expanded="false" type="button">

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -1,7 +1,8 @@
 <section class="section" id="homeHero" aria-label="What is Servo">
   <div class="hero-body">
     <div class="container">
-      <img class="hero-img" src="{{ site.logoPositive | url }}" alt="{{ title }}">
+      <img class="hero-img hero-img--light" src="{{ site.logoPositive | url }}" alt="{{ title }}">
+      <img class="hero-img hero-img--dark" src="{{ '/svg/servo-color-negative-no-container.svg' | url }}" alt="{{ title }}">
       <h1 class="title center-text">
         Servo aims to empower developers with a lightweight, high-performance alternative for embedding web technologies in applications.
       </h1>

--- a/_includes/sponsorship.html
+++ b/_includes/sponsorship.html
@@ -204,6 +204,8 @@
 }
 
 .inner-container__logos {
+  background-color: #ffffff;
+  color: #2d3748;
   border: 1px solid var(--midturquoise);
   max-width: 800px;
   margin-left: auto;
@@ -213,10 +215,19 @@
 }
 
 .inner-container__logos h3 {
+  color: #1a202c;
   border-bottom: 1px solid var(--midturquoise);
   padding-top: var(--12px);
   padding-bottom: var(--12px);
   font-size: var(--step-1);
+}
+
+.inner-container__logos a {
+  color: var(--midturquoise);
+}
+
+.inner-container__logos a:hover {
+  color: var(--darkturquoise);
 }
 
 </style>

--- a/assets/css/style.css.liquid
+++ b/assets/css/style.css.liquid
@@ -18,15 +18,17 @@ permalink: /css/style.css
   --bg-dropdown: #ffffff;
   --bg-card: #ffffff;
   --bg-code: #f1f5f9;
+  --bg-footer: #4b4b4b;
 
   --text-primary: #2d3748;
   --text-secondary: #4b4b4b;
   --text-muted: #696969;
   --text-title: #1a202c;
+  --text-inverse: #ffffff;
 
   --border-color: #e3e8f0;
-  --border-subtle: hs1(0, 0%, 90%);
-  --nav-hover-bg: hsl(0, 0%, 95;
+  --border-subtle: hsl(0, 0%, 90%);
+  --nav-hover-bg: hsl(0, 0%, 95%);
   --dropdown-shadow: 0px 6px 4px rgba(0, 0, 0, .07), 0px 6px 30px rgba(0, 0, 0, .06), 0px 8px 10px rgba(0, 0, .1);
 
   --turquoise: #209e9b;
@@ -67,16 +69,18 @@ permalink: /css/style.css
   --bg-dropdown: #1e293b;
   --bg-card: #171f2c;
   --bg-code: #1e293b;
+  --bg-footer: #0b1220;
 
-  --text-primary: #e2ee8f0;
+  --text-primary: #e2e8f0;
   --text-secondary: #94a3b8;
   --text-muted: #64748b;
   --text-title: #f8fafc;
+  --text-inverse: #ffffff;
 
   --border-color: #334155;
   --border-subtle: #1e293b;
   --nav-hover-bg: rgba(255, 255, 255, 0.08);
-  --dropdown-shadow: 0px 8px 24px rgba(0, 0, 0, 0.5;
+  --dropdown-shadow: 0px 8px 24px rgba(0, 0, 0, 0.5);
 
   --dark-grey: #cbd5e1;
   --light-grey: #94a3b8;
@@ -152,8 +156,8 @@ textarea:not([rows]) {
 /* Site Styles Begin */
 
 body {
-  background-color: var(--white);
-  color: var(--dark-grey);
+  background-color: var(--bg-page);
+  color: var(--text-primary);
   margin: 0;
   overflow-x: hidden;
   display: flex;
@@ -218,11 +222,11 @@ p + iframe {
 }
 
 a {
-  color: var(--midturquoise);
+  color: var(--color-primary);
 }
 
 a:hover {
-  color: var(--darkturquoise)
+  color: var(--color-primary-hover)
 }
 
 
@@ -244,7 +248,7 @@ a:hover {
 }
 
 .cta-text {
-  color: var(--turquoise);
+  color: var(--color-primary);
   margin: 0 auto;
   padding: var(--48px) 0;
 }
@@ -326,11 +330,11 @@ nav .inner-container {
   .navbar-item {
     display: block;
     position: relative;
-    color: var(--dark-grey);
+    color: var(--text-primary);
   }
 
   .navbar-link {
-    color: var(--dark-grey);
+    color: var(--text-primary);
     position: relative;
 }
 
@@ -342,7 +346,7 @@ nav .inner-container {
 
   .navbar-link:hover,
   .navbar-dropwdown a.navbar-item:hover {
-    background-color: hsl(0, 0%, 95%)
+    background-color: var(--nav-hover-bg)
   }
 
 
@@ -350,12 +354,12 @@ nav .inner-container {
   .navbar-link:focus, .navbar-link:focus-within, .navbar-link:hover,
   .navbar-item.has-dropdown:hover .navbar-link
    {
-    background-color: hsl(0, 0%, 95%);
-    color: var(--midturquoise);
+    background-color: var(--nav-hover-bg);
+    color: var(--color-primary);
   }
 
   .navbar-item:visited {
-    color: var(--dark-grey);
+    color: var(--text-primary);
   }
 
 .has-dropdown .navbar-link {
@@ -382,13 +386,37 @@ nav .inner-container {
 }
 
 .has-dropdown .navbar-link::after {
-  border-color: var(--dark-grey);
+  border-color: var(--text-primary);
   margin-top: -0.375em;
   right: .5em;;
 }
 
-.navbar-item .has-dropdown:hover {
-  background-color: var(--white);
+.navbar-item.has-dropdown:hover {
+  background-color: var(--bg-dropdown);
+}
+
+.logo-dark,
+.theme-toggle-btn .fa-sun {
+  display: none;
+}
+
+[data-theme="dark"] .logo-light,
+[data-theme="dark"] .theme-toggle-btn .fa-moon {
+  display: none;
+}
+
+[data-theme="dark"] .logo-dark,
+[data-theme="dark"] .theme-toggle-btn .fa-sun {
+  display: inline-block;
+}
+
+.theme-toggle-btn {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: .5rem;
 }
 
 .navbar-end {
@@ -441,7 +469,7 @@ nav .inner-container {
     top: calc(50% + 4px);
   }
   .navbar-burger:hover {
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: var(--nav-hover-bg);
   }
   .navbar-burger.is-active span:nth-child(1) {
     transform: translateY(5px) rotate(45deg);
@@ -621,8 +649,8 @@ footer .logo {
 }
 
 .footer {
-  background-color: var(--dark-grey);
-  color: var(--white);
+  background-color: var(--bg-footer);
+  color: var(--text-inverse);
   padding: var(--48px) 0;
   border-top-left-radius: 2.25rem;
   border-top-right-radius: 2.25rem;
@@ -639,7 +667,7 @@ footer p {
 }
 
 a.footer-link {
-  color: var(--white);
+  color: var(--text-inverse);
   text-decoration: underline;
 }
 
@@ -664,7 +692,7 @@ figcaption {
 }
 
 #Blog .summary {
-  color: var(--dark-grey);
+  color: var(--text-primary);
   font-size: var(--step-0);
 }
 
@@ -701,7 +729,7 @@ figcaption {
 
   .blog-content h2,
   .blog-content h3 {
-    color: var(--dark-grey);
+    color: var(--text-title);
   }
 
   .blog-content p {
@@ -738,7 +766,7 @@ figcaption {
   .subpage-content h1,
   .subpage-content h2,
   .subpage-content h3 {
-    color: var(--dark-grey);
+    color: var(--text-title);
   }
 
   .subpage-content * + h2,
@@ -954,11 +982,9 @@ a.button {
     top: 64px;
     left: 0;
     z-index: 20;
-    background-color: var(--white);
+    background-color: var(--bg-dropdown);
     min-width: max-content;
-    box-shadow: 0px 6px 4px rgba(0, 0, 0, .07),
-    0px 6px 30px rgba(0, 0, 0, .06),
-    0px 8px 10px rgba(0, 0, 0, .1);
+    box-shadow: var(--dropdown-shadow);
     border-radius: 4px;
   }
 
@@ -1032,7 +1058,7 @@ a.button {
   }
 
   .navbar-menu {
-      background-color: var(--white);
+      background-color: var(--bg-dropdown);
       min-height: 3.25rem;
       position: relative;
       z-index: 30;

--- a/assets/css/style.css.liquid
+++ b/assets/css/style.css.liquid
@@ -8,6 +8,27 @@ permalink: /css/style.css
 /* @link https://utopia.fyi/type/calculator?c=320,16,1.414,1680,16,1.414,5,2,&s=0.75|0.5|0.25,1.5|2|3|4|6,s-l&g=s,l,xl,12 */
 
 :root {
+  /* Expand styling to properly impl light and dark mode*/
+  --color-primary: #1B8381;
+  --color-primary-hover: #004746;
+  --color-accent: #209e9b;
+
+  --bg-page: #ffffff;
+  --bg-surface: #f8fafc;
+  --bg-dropdown: #ffffff;
+  --bg-card: #ffffff;
+  --bg-code: #f1f5f9;
+
+  --text-primary: #2d3748;
+  --text-secondary: #4b4b4b;
+  --text-muted: #696969;
+  --text-title: #1a202c;
+
+  --border-color: #e3e8f0;
+  --border-subtle: hs1(0, 0%, 90%);
+  --nav-hover-bg: hsl(0, 0%, 95;
+  --dropdown-shadow: 0px 6px 4px rgba(0, 0, 0, .07), 0px 6px 30px rgba(0, 0, 0, .06), 0px 8px 10px rgba(0, 0, .1);
+
   --turquoise: #209e9b;
   --midturquoise: #1B8381;
   --darkturquoise: #004746;
@@ -33,6 +54,32 @@ permalink: /css/style.css
   --step-3: clamp(1.728rem, 1.6176rem + 0.5521vw, 2.1973rem);
   --step-4: clamp(2.0736rem, 1.9153rem + 0.7917vw, 2.7466rem);
   --step-5: clamp(2.4883rem, 2.266rem + 1.1117vw, 3.4332rem);
+}
+
+/* Overrides for dark theme */
+[data-theme="dark"] {
+  --color-primary: #2dd4bf;
+  --color-primary-hover: #5eead4;
+  --color-accent: #14b8a6;
+
+  --bg-page: #0f141c;
+  --bg-surface: #171f2c;
+  --bg-dropdown: #1e293b;
+  --bg-card: #171f2c;
+  --bg-code: #1e293b;
+
+  --text-primary: #e2ee8f0;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+  --text-title: #f8fafc;
+
+  --border-color: #334155;
+  --border-subtle: #1e293b;
+  --nav-hover-bg: rgba(255, 255, 255, 0.08);
+  --dropdown-shadow: 0px 8px 24px rgba(0, 0, 0, 0.5;
+
+  --dark-grey: #cbd5e1;
+  --light-grey: #94a3b8;
 }
 
 /* CSS Reset */
@@ -123,7 +170,7 @@ body {
   flex: 1;
 }
 
-h1, 
+h1,
 h2,
 h3,
 h4,
@@ -299,8 +346,8 @@ nav .inner-container {
   }
 
 
-  a.navbar-item:focus, a.navbar-item:focus-within, a.navbar-item:hover, 
-  .navbar-link:focus, .navbar-link:focus-within, .navbar-link:hover, 
+  a.navbar-item:focus, a.navbar-item:focus-within, a.navbar-item:hover,
+  .navbar-link:focus, .navbar-link:focus-within, .navbar-link:hover,
   .navbar-item.has-dropdown:hover .navbar-link
    {
     background-color: hsl(0, 0%, 95%);
@@ -343,7 +390,7 @@ nav .inner-container {
 .navbar-item .has-dropdown:hover {
   background-color: var(--white);
 }
-    
+
 .navbar-end {
   display: flex;
 }
@@ -502,7 +549,7 @@ nav .inner-container {
       padding-bottom: .5rem;
       max-width: 64.25rem;
     }
-      
+
     .blog .card-content .post-summary {
       font-size: var(--step-0);
       max-width: 64.25rem;
@@ -540,10 +587,10 @@ nav .inner-container {
       color: var(--white);
     }
 
-/* Sponsorship */ 
+/* Sponsorship */
 .sponsorship h2 {
   color: var(--darkturquoise);
-}    
+}
 
 
 /* Contact */
@@ -909,8 +956,8 @@ a.button {
     z-index: 20;
     background-color: var(--white);
     min-width: max-content;
-    box-shadow: 0px 6px 4px rgba(0, 0, 0, .07), 
-    0px 6px 30px rgba(0, 0, 0, .06), 
+    box-shadow: 0px 6px 4px rgba(0, 0, 0, .07),
+    0px 6px 30px rgba(0, 0, 0, .06),
     0px 8px 10px rgba(0, 0, 0, .1);
     border-radius: 4px;
   }
@@ -961,7 +1008,7 @@ a.button {
     display: none;
 }
 
-.navbar-item.is-active .navbar-dropdown, .navbar-item.is-hoverable:focus .navbar-dropdown, 
+.navbar-item.is-active .navbar-dropdown, .navbar-item.is-hoverable:focus .navbar-dropdown,
 .navbar-item.is-hoverable:focus-within .navbar-dropdown, .navbar-item.is-hoverable:hover .navbar-dropdown {
     display: block;
 }
@@ -982,7 +1029,7 @@ a.button {
 
   .navbar-menu.is-active {
     display: block;
-  } 
+  }
 
   .navbar-menu {
       background-color: var(--white);
@@ -1013,7 +1060,7 @@ a.button {
         padding: .5rem 2rem;
       }
 
-    /* Mobile Hover Nav Selection */  
+    /* Mobile Hover Nav Selection */
     a.navbar-item,
     .navbar-item.has-dropdown .navbar-link {
       padding: .5rem 2rem .5rem .5rem;
@@ -1026,7 +1073,7 @@ a.button {
     .has-dropdown .navbar-link::after {
       right: 1.25rem;
     }
-  
+
   .blog > .inner-container {
     padding: 0 var(--24px);
   }

--- a/assets/css/style.css.liquid
+++ b/assets/css/style.css.liquid
@@ -395,17 +395,14 @@ nav .inner-container {
   background-color: var(--bg-dropdown);
 }
 
-.logo-dark,
 .theme-toggle-btn .fa-sun {
   display: none;
 }
 
-[data-theme="dark"] .logo-light,
 [data-theme="dark"] .theme-toggle-btn .fa-moon {
   display: none;
 }
 
-[data-theme="dark"] .logo-dark,
 [data-theme="dark"] .theme-toggle-btn .fa-sun {
   display: inline-block;
 }
@@ -547,6 +544,18 @@ nav .inner-container {
   width: 100%;
   margin: 0 auto;
   padding: var(--24px) 0;
+}
+
+.hero-img--dark {
+  display: none;
+}
+
+[data-theme="dark"] .hero-img--light {
+  display: none;
+}
+
+[data-theme="dark"] .hero-img--dark {
+  display: block;
 }
 
 /* Blog Feature */

--- a/assets/css/style.css.liquid
+++ b/assets/css/style.css.liquid
@@ -657,6 +657,18 @@ footer .logo {
   padding-bottom: 2.25rem;
 }
 
+.footer-logo--dark {
+  display: none;
+}
+
+[data-theme="dark"] .footer-logo--light {
+  display: none;
+}
+
+[data-theme="dark"] .footer-logo--dark {
+  display: inline;
+}
+
 .footer {
   background-color: var(--bg-footer);
   color: var(--text-inverse);


### PR DESCRIPTION
Description: 
- Adding dark mode for servo.org. Mostly css changes with toggle and pull mode for localStorage. 
- We might have to update an png of wiki-servo in dark mode. I am leaving it out for now.

**Note**: Apologies for the sizing of the images. 

Fixes: https://github.com/servo/servo.org/issues/206
<img width="1719" height="1276" alt="Screenshot 2026-09-01 at 22 28 00" src="https://github.com/user-attachments/assets/577988cf-bef3-4dfe-a821-a6c12c592d75" />
<img width="1727" height="1291" alt="Screenshot 2026-09-01 at 22 28 13" src="https://github.com/user-attachments/assets/d07fb9dc-5288-45db-b209-2b70fa0799b7" />
<img width="1722" height="1158" alt="Screenshot 2026-09-01 at 22 28 22" src="https://github.com/user-attachments/assets/c5efbdca-a89c-4724-b2bd-43b402c00e49" />
