### PR TITLE
Re-add TestMu as bronze sponsor

### DIFF
--- a/_data/sponsors.json
+++ b/_data/sponsors.json
@@ -39,5 +39,11 @@
     "name": "str4d",
     "url": "https://str4d.xyz/",
     "type": "bronze"
+  },
+  {
+    "name": "TestMu AI",
+    "url": "https://www.testmuai.com/?utm_medium=sponsor&utm_source=servo",
+    "img": "/img/logos/testmu.png",
+    "type": "bronze"
   }
 ]


### PR DESCRIPTION
We removed them in #326, but since then they have re-started payments: https://opencollective.com/servo/transactions?searchTerm=testmu&kind=ADDED_FUNDS&kind=CONTRIBUTION&kind=EXPENSE&kind=BALANCE_TRANSFER

They have contacted us and mentioned it was a credit card that expired.